### PR TITLE
Make desktop file pass desktop-file-validate

### DIFF
--- a/snapcraft/setup/gui/ubports-installer.desktop
+++ b/snapcraft/setup/gui/ubports-installer.desktop
@@ -2,4 +2,5 @@
 Name=Ubports installer
 Exec=ubports-installer
 Type=Application
-Icon=/snap/ubports-installer/current/meta/gui/icon.png
+Icon=ubports-installer
+Categories=System;


### PR DESCRIPTION
Please note that for this to work, you need to put an icon called `ubports-installer.png` into the usual location.

Reference:
https://travis-ci.org/AppImage/appimage.github.io#L578

The current desktop file does not pass validation and prevents the application from being listed on AppImageHub, the central directory of available AppImages.