### PR TITLE
Workaround file path with whitespaces

### DIFF
--- a/src/adb.js
+++ b/src/adb.js
@@ -142,7 +142,8 @@ var isBaseUbuntuCom = callback => {
 var push = (file, dest, pushEvent) => {
   var done;
   var fileSize = fs.statSync(file)["size"];
-  utils.platfromToolsExec("adb", ["-P", PORT, "push", file, dest], (err, stdout, stderr) => {
+  // TODO: better file path sanitizing
+  utils.platfromToolsExec("adb", ["-P", PORT, "push", "'"+file+"'", dest], (err, stdout, stderr) => {
     done=true;
     if (err !== null) {
       pushEvent.emit("adbpush:error", err+" stdout: " + stdout.length > 50*1024 ? "overflow" : stdout + " stderr: " + stderr.length > 50*1024 ? "overflow" : stderr)


### PR DESCRIPTION
When I try to install with Mac OS High Sierra
```
adb -P PORT push /Users/bar/Library/Application Support/ubports/pool/ubports-foo.tar.xz /cache/recovery/
```
Above cmd cause an error, following workaround may fix this issue.
```
adb -P PORT push '/Users/bar/Library/Application Support/ubports/pool/ubports-foo.tar.xz' /cache/recovery/
```
Actually, this fix may fail if file path contains char `'`.