### PR TITLE
Properly escape password everywhere

### DIFF
--- a/src/adb.js
+++ b/src/adb.js
@@ -27,7 +27,7 @@ const start = (password, sudo, callback) => {
   stop(err => {
     var cmd="";
     if (utils.needRoot() && sudo)
-        cmd += utils.sudoCommand(password, "");
+        cmd += utils.sudoCommand(password);
     cmd += adb + " -P " + PORT + " start-server";
     utils.platfromToolsExecAsar("adb", (platfromToolsExecAsar) => {
         platfromToolsExecAsar.exec(cmd, (c, r, e) => {

--- a/src/adb.js
+++ b/src/adb.js
@@ -27,7 +27,7 @@ const start = (password, sudo, callback) => {
   stop(err => {
     var cmd="";
     if (utils.needRoot() && sudo)
-        cmd += "echo " + password + " | sudo -S "
+        cmd += utils.sudoCommand(password, "");
     cmd += adb + " -P " + PORT + " start-server";
     utils.platfromToolsExecAsar("adb", (platfromToolsExecAsar) => {
         platfromToolsExecAsar.exec(cmd, (c, r, e) => {

--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -48,7 +48,7 @@ var waitForDevice = (password, callback) => {
     utils.log.debug("fastboot: wait for device");
     var cmd = "";
     if (utils.needRoot())
-        cmd += "echo " + password + " | sudo -S "
+        cmd += utils.sudoCommand(password, "");
     cmd += "fastboot" + " devices";
     var stop;
     utils.platfromToolsExecAsar("fastboot", (asarExec) => {
@@ -106,7 +106,7 @@ var flash = (images, callback, password) => {
     var cmd = "";
     images.forEach((image, l) => {
         if (utils.needRoot())
-            cmd += "echo " + password + " | sudo -S "
+            cmd += utils.sudoCommand(password, "");
         cmd += "fastboot" + " flash " + image.type + " \"" + path.join(image.path, path.basename(image.url)) + "\"";
         if (l !== images.length - 1)
             cmd += " && "
@@ -135,7 +135,7 @@ image object format
 var boot = (image, password, callback) => {
   var cmd="";
   if (utils.needRoot())
-      cmd += "echo " + password + " | sudo -S "
+      cmd += utils.sudoCommand(password, "");
   cmd += "fastboot" + " boot \"" + path.join(image.path, path.basename(image.url)) + "\"";
   utils.platfromToolsExecAsar("fastboot", (asarExec) => {
       asarExec.exec(cmd, (c, r, e) => {
@@ -153,7 +153,7 @@ var format = (partitions, password, callback) => {
   var cmd="";
   partitions.forEach((partition, l) => {
       if (utils.needRoot())
-          cmd += "echo " + password + " | sudo -S "
+          cmd += utils.sudoCommand(password, "");
       cmd += "fastboot" + " format " + partition;
       if (l !== partitions.length - 1)
           cmd += " && "
@@ -174,7 +174,7 @@ args; array, string, function
 var oem = (command, password, callback) => {
   var cmd="";
   if (utils.needRoot())
-      cmd += "echo " + password + " | sudo -S "
+      cmd += utils.sudoCommand(password, "");
   cmd += "fastboot" + " oem " + command;
   utils.platfromToolsExecAsar("fastboot", (asarExec) => {
       asarExec.exec(cmd, (c, r, e) => {

--- a/src/fastboot.js
+++ b/src/fastboot.js
@@ -48,7 +48,7 @@ var waitForDevice = (password, callback) => {
     utils.log.debug("fastboot: wait for device");
     var cmd = "";
     if (utils.needRoot())
-        cmd += utils.sudoCommand(password, "");
+        cmd += utils.sudoCommand(password);
     cmd += "fastboot" + " devices";
     var stop;
     utils.platfromToolsExecAsar("fastboot", (asarExec) => {
@@ -106,7 +106,7 @@ var flash = (images, callback, password) => {
     var cmd = "";
     images.forEach((image, l) => {
         if (utils.needRoot())
-            cmd += utils.sudoCommand(password, "");
+            cmd += utils.sudoCommand(password);
         cmd += "fastboot" + " flash " + image.type + " \"" + path.join(image.path, path.basename(image.url)) + "\"";
         if (l !== images.length - 1)
             cmd += " && "
@@ -135,7 +135,7 @@ image object format
 var boot = (image, password, callback) => {
   var cmd="";
   if (utils.needRoot())
-      cmd += utils.sudoCommand(password, "");
+      cmd += utils.sudoCommand(password);
   cmd += "fastboot" + " boot \"" + path.join(image.path, path.basename(image.url)) + "\"";
   utils.platfromToolsExecAsar("fastboot", (asarExec) => {
       asarExec.exec(cmd, (c, r, e) => {
@@ -153,7 +153,7 @@ var format = (partitions, password, callback) => {
   var cmd="";
   partitions.forEach((partition, l) => {
       if (utils.needRoot())
-          cmd += utils.sudoCommand(password, "");
+          cmd += utils.sudoCommand(password);
       cmd += "fastboot" + " format " + partition;
       if (l !== partitions.length - 1)
           cmd += " && "
@@ -174,7 +174,7 @@ args; array, string, function
 var oem = (command, password, callback) => {
   var cmd="";
   if (utils.needRoot())
-      cmd += utils.sudoCommand(password, "");
+      cmd += utils.sudoCommand(password);
   cmd += "fastboot" + " oem " + command;
   utils.platfromToolsExecAsar("fastboot", (asarExec) => {
       asarExec.exec(cmd, (c, r, e) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -130,8 +130,8 @@ var die = (e) => {
     process.exit(1);
 }
 
-var sudoCommand = (password, cmd) => {
-    return "echo \'" + password.replace(/\'/g, "'\\''") + "\' | sudo -S " + cmd;
+var sudoCommand = (password) => {
+    return "echo '" + password.replace(/\'/g, "'\\''") + "' | sudo -S ";
 }
 
 var checkPassword = (password, callback) => {
@@ -141,7 +141,7 @@ var checkPassword = (password, callback) => {
         return;
     }
     log.debug("checking password")
-    exec(sudoCommand(password, "echo correct"), (err, output) => {
+    exec(sudoCommand(password) + "echo correct", (err, output) => {
         if(err){
             if (err.message.includes("incorrect password")) {
                 log.debug("incorrect password")

--- a/src/utils.js
+++ b/src/utils.js
@@ -130,6 +130,10 @@ var die = (e) => {
     process.exit(1);
 }
 
+var sudoCommand = (password, cmd) => {
+    return "echo \'" + password.replace(/\'/g, "'\\''") + "\' | sudo -S " + cmd;
+}
+
 var checkPassword = (password, callback) => {
     if (!needRoot()) {
         log.debug("no root needed")
@@ -137,7 +141,7 @@ var checkPassword = (password, callback) => {
         return;
     }
     log.debug("checking password")
-    exec("echo \"" + password.replace(/\"/g, "\\\"") + "\" | sudo -S echo correct", (err, output) => {
+    exec(sudoCommand(password, "echo correct"), (err, output) => {
         if(err){
             if (err.message.includes("incorrect password")) {
                 log.debug("incorrect password")
@@ -450,6 +454,7 @@ module.exports = {
     getPlatformTools: getPlatformTools,
     getUbportDir: getUbportDir,
     needRoot: needRoot,
+    sudoCommand: sudoCommand,
     checkPassword: checkPassword,
     debugScreen: debugScreen,
     debugTrigger: debugTrigger,


### PR DESCRIPTION
This should fix #88 by introducing a helper function and escaping the password everywhere.
Are you fine with the function name? I can remove the `cmd` parameter if you'd prefer it to just return the correct sudo command. 
Note that it currently appends an unnecessary space when called with empty `cmd` parameter.
Is `utils` the correct place for the function?