### PR TITLE
Add alias for PRO5 = turbo

### DIFF
--- a/src/adb.js
+++ b/src/adb.js
@@ -67,7 +67,8 @@ const lazyOverrideAlias = (func, arg, callback) => {
     "a0001": "bacon",
     "find7op": "bacon",
     "nexus5": "hammerhead",
-    "fairphone2": "FP2"
+    "fairphone2": "FP2",
+    "PRO5": "turbo"
   }
   func(device => {
     if (device in alias)


### PR DESCRIPTION
As reported by Rudy on Telegram, the Pro 5 sometimes reports itself as PRO5. This adds the alias.