### PR TITLE
Fix broken error report in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,20 @@
   "name": "ubports-installer",
   "version": "0.1.21-beta",
   "description": "UBports Installer: The easy way to install Ubuntu Touch on UBports devices. A friendly cross-platform Installer for Ubuntu Touch. Just connect a supported device to your PC, follow the on-screen instructions and watch this awesome tool do all the rest.",
-  "keywords": ["Ubuntu", "Ubuntu Touch", "UBports", "UBports Installer", "Android", "ADB", "Fastboot", "Heimdall"],
+  "keywords": [
+    "Ubuntu",
+    "Ubuntu Touch",
+    "UBports",
+    "UBports Installer",
+    "Android",
+    "ADB",
+    "Fastboot",
+    "Heimdall"
+  ],
   "homepage": "https://devices.ubuntu-touch.io",
   "bugs": {
-    "url" : "https://github.com/ubports/ubports-installer/issues",
-    "email" : "info@ubports.com"
+    "url": "https://github.com/ubports/ubports-installer/issues",
+    "email": "info@ubports.com"
   },
   "repository": "https://github.com/ubports/ubports-installer",
   "author": "UBports Foundation <info@ubports.com>",
@@ -45,8 +54,8 @@
     "checksum": "^0.1.1",
     "command-exists": "^1.2.2",
     "commander": "^2.9.0",
-    "electron-pug": "^1.5.1",
     "electron-open-link-in-browser": "^1.0.2",
+    "electron-pug": "^1.5.1",
     "electron-sudo": "^3.0.13",
     "executable": "^4.1.0",
     "forward-emitter": "^0.1.1",
@@ -56,7 +65,6 @@
     "jquery": "^3.1.1",
     "jquery-i18next": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "openurl": "^1.1.1",
     "request": "^2.79.0",
     "request-progress": "^3.0.0",
     "system-image-node-module": "1.0.5",

--- a/src/html/modals/error.pug
+++ b/src/html/modals/error.pug
@@ -7,12 +7,12 @@
         h4.modal-title Yikes!
       .modal-body
         p The Installation stopped due to a problem. You can choose to ignore this, or re-start the installation process.
-        p If this continues to happen, please check if you are affected by  #[a(onclick="openurl.open('https://github.com/ubports/ubports-installer/issues')") a known bug].
+        p If this continues to happen, please check if you are affected by  #[a(onclick="shell.openExternal('https://github.com/ubports/ubports-installer/issues')") a known bug].
         p If your problem is not yet known, klick the button below to report a new bug.
         pre#error-body.
           \n
         p#not-latest-stable(hidden='hidden') You are not using the latest stable version of the UBports Installer.
-        #generic-update-instructions-error.p(hidden='hidden') You can #[a(onclick="openurl.open('https://github.com/ubports/ubports-installer/issues')") download the latest version from GitHub].
+        #generic-update-instructions-error.p(hidden='hidden') You can #[a(onclick="shell.openExternal('https://github.com/ubports/ubports-installer/issues')") download the latest version from GitHub].
         #snap-update-instructions-error.p(hidden='hidden') Run #[code snap refresh ubports-installer --stable] in your terminal to install the latest version.
       .modal-footer
         button.btn.btn-default(type='button', hidden='hidden', data-dismiss='modal', onclick="location.reload(); utils.log.info('STARTING OVER')") Try again

--- a/src/html/modals/new-update.pug
+++ b/src/html/modals/new-update.pug
@@ -11,4 +11,4 @@
         #snap-update-instructions.p(hidden='hidden') Run #[code snap refresh ubports-installer --stable] in your terminal to install the latest version.
       .modal-footer
         button.btn.btn-default(type='button', data-dismiss='modal') Dismiss
-        button#btn-update-installer.btn.btn-primary(type='button', onclick="openurl.open('https://github.com/ubports/ubports-installer/releases/latest')") Download
+        button#btn-update-installer.btn.btn-primary(type='button', onclick="shell.openExternal('https://github.com/ubports/ubports-installer/releases/latest')") Download

--- a/src/html/modals/options.pug
+++ b/src/html/modals/options.pug
@@ -12,7 +12,7 @@
               label.col-xs-3.control-label Channel
               .col-xs-9
                 select#options-channel.form-control.space
-                .help-block  #[a(onclick="openurl.open('https://docs.ubports.com/en/latest/about/process/release-schedule.html')") What is this]?
+                .help-block  #[a(onclick="shell.openExternal('https://docs.ubports.com/en/latest/about/process/release-schedule.html')") What is this]?
             .form-group
               .col-xs-3
                 label

--- a/src/html/modals/windows-drivers.pug
+++ b/src/html/modals/windows-drivers.pug
@@ -7,10 +7,10 @@
         h4.modal-title Warning!
       .modal-body
         p
-          | You need to install the #[a(onclick="openurl.open('https://adb.clockworkmod.com/')") Universal ADB driver] and re-start the program to continue with the installation.
+          | You need to install the #[a(onclick="shell.openExternal('https://adb.clockworkmod.com/')") Universal ADB driver] and re-start the program to continue with the installation.
           | If you have already installed adb drivers, you can dismiss this message and simply continue with the installation.
           br
-          | If installer still does not detect you device, you might want to try installing   #[a(onclick="openurl.open('https://developer.android.com/studio/releases/')") Android Studio] from Google. After that, you can specify custom adb and fastboot tools in the options in the next step.
+          | If installer still does not detect you device, you might want to try installing   #[a(onclick="shell.openExternal('https://developer.android.com/studio/releases/')") Android Studio] from Google. After that, you can specify custom adb and fastboot tools in the options in the next step.
           br
           | Please note that the UBports Installer is still somewhat unstable on Windows. If the installation does not work on this machine and you have access to a Linux computer, you might want to try your luck there.
       .modal-footer

--- a/src/html/scripts/main.pug
+++ b/src/html/scripts/main.pug
@@ -16,7 +16,7 @@ script.
   $("#btn-bugreport").click(() => {
     var title = $("#error-body").text();
     utils.createBugReport(title, (body) => {
-      openurl.open("https://github.com/ubports/ubports-installer/issues/new?title="+title+"&body="+body);
+      shell.openExternal("https://github.com/ubports/ubports-installer/issues/new?title="+title+"&body="+body);
     });
   })
   window.onerror = (err, url, line) => {
@@ -98,7 +98,7 @@ script.
 
     $("#help").click(() => {
       utils.createBugReport("user-requested error report", (body) => {
-        openurl.open("https://github.com/ubports/ubports-installer/issues/new?title=please describe the problem you are experiencing&body="+body);
+        shell.openExternal("https://github.com/ubports/ubports-installer/issues/new?title=please describe the problem you are experiencing&body="+body);
       });
     });
 
@@ -143,7 +143,7 @@ script.
           footer.underText.set("Please connect your " + output.device.name + " with a USB cable.");
         $("#your-ubp-device").text(output.device.name+" ("+output.device.device+")")
         $("#your-ubp-device").click(() => {
-            openurl.open("https://devices.ubuntu-touch.io/device/"+output.device.device);
+            shell.openExternal("https://devices.ubuntu-touch.io/device/"+output.device.device);
         })
         var notWorking = devices.getFormatedNotWorking(output.device.whatIsWorking);
         if (notWorking)

--- a/src/html/scripts/root.pug
+++ b/src/html/scripts/root.pug
@@ -1,7 +1,7 @@
 script.
   require('jquery')
   window.$ = window.jQuery = require('../../node_modules/jquery/dist/jquery.js');
-  const openurl = require("openurl");
+  const { shell } = require('electron');
   const devices = require('../devices.js');
   const systemImage = require("../system-image.js");
   const adb = require("../adb.js");

--- a/src/html/views/done.pug
+++ b/src/html/views/done.pug
@@ -7,8 +7,8 @@
       p
         | The installation process from the computer is done. The device will now perform the remaining steps which should take less than five minutes. After the installation, the device will reboot and you can begin to explore Ubuntu Touch.
       p
-        | Found something you don't like?  #[a(onclick="openurl.open('https://github.com/ubports/ubports-touch')") tell us], or help us change it!
-      button.btn.btn-default(type='button', style='width: 100%; margin-bottom: 10px;', onclick="openurl.open('https://ubports.com/get-involved')") Get involved
+        | Found something you don't like?  #[a(onclick="shell.openExternal('https://github.com/ubports/ubports-touch')") tell us], or help us change it!
+      button.btn.btn-default(type='button', style='width: 100%; margin-bottom: 10px;', onclick="shell.openExternal('https://ubports.com/get-involved')") Get involved
       p
-        | Development of Ubuntu Touch is driven by the  #[a(onclick="openurl.open('https://ubports.com')") UBports Community]. Donate now to allow us to continue our mission!
-      button.btn.btn-primary(type='button', style='width: 100%;', onclick="openurl.open('https://ubports.com/donate')") Donate
+        | Development of Ubuntu Touch is driven by the  #[a(onclick="shell.openExternal('https://ubports.com')") UBports Community]. Donate now to allow us to continue our mission!
+      button.btn.btn-primary(type='button', style='width: 100%;', onclick="shell.openExternal('https://ubports.com/donate')") Donate

--- a/src/html/views/install.pug
+++ b/src/html/views/install.pug
@@ -9,7 +9,7 @@
       #switch-note(hidden='hidden')
         p This device is running old Canonical images!
       #legacy-android-note(hidden='hidden')
-        p If your device is running Android, you might have to #[a(onclick="openurl.open('https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices')") install the old Ubuntu Touch version from Canonical] first to unlock the bootloader.
+        p If your device is running Android, you might have to #[a(onclick="shell.openExternal('https://docs.ubports.com/en/latest/userguide/install.html#install-on-legacy-android-devices')") install the old Ubuntu Touch version from Canonical] first to unlock the bootloader.
       p#not-working-block
         b Please note
         |  that this device is still under development. There might be issues with 

--- a/src/html/views/not-supported.pug
+++ b/src/html/views/not-supported.pug
@@ -12,10 +12,10 @@
         | , there is no port for this device yet!
       p
         | See 
-        a(onclick="openurl.open('http://devices.ubuntu-touch.io')") devices.ubuntu-touch.io
+        a(onclick="shell.openExternal('http://devices.ubuntu-touch.io')") devices.ubuntu-touch.io
         |  for more info
       hr
       h4(style='font-weight: bold;') You want to try to install anyway?
       p
-        | You can try selecting your device manualy, but please only do so if you're sure that your exact model is actually supported! You might also want to #[a(onclick="openurl.open('http://devices.ubuntu-touch.io')") file a bug].
+        | You can try selecting your device manualy, but please only do so if you're sure that your exact model is actually supported! You might also want to #[a(onclick="shell.openExternal('http://devices.ubuntu-touch.io')") file a bug].
       button#btn-modal-select-device-unsupported.btn.btn-default(type='button', style='width: 100%;') Select device manually

--- a/src/html/views/wait-for-device.pug
+++ b/src/html/views/wait-for-device.pug
@@ -7,5 +7,5 @@
       p Welcome to the UBports Installer! This tool will walk you through the Ubuntu Touch installation process. Don't worry, it's easy!
       p Connect your device to the computer and enable developer mode. After that, your device should be detected automatically.
       button#btn-modal-dev-mode.btn.btn-primary(type='button', style='width: 100%; margin-bottom: 10px;') How do I enable developer mode?
-      p If your device is not detected automatically, you can select it manually to proceed. Please note that the UBports Installer will only work on #[a(onclick="openurl.open('http://devices.ubuntu-touch.io')") supported devices].
+      p If your device is not detected automatically, you can select it manually to proceed. Please note that the UBports Installer will only work on #[a(onclick="shell.openExternal('http://devices.ubuntu-touch.io')") supported devices].
       button#btn-modal-select-device.btn.btn-default(type='button', style='width: 100%;') Select device manually


### PR DESCRIPTION
That obscure bug happened in Windows x64 as well as x32. The root cause was the `openurl` module which spawns `explorer.exe` with the URL as the argument, that it treats it as a file path. Windows has a limit of 260 characters long for paths and it truncates the error message as a result (welp, windows is windows :confused:)

More info here: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#maximum-path-length-limitation

The fix is as easy as to use the methods that provide electron. electron.shell.openExternal() does the trick and it has a limit of 2081 characters long on Windows, so as long as the error report URL doesn't exceed that limit we're good :satisfied:

More info: https://electronjs.org/docs/api/shell#shellopenexternalurl-options-callback

Fixes #224