### PR TITLE
Use correct build dependencies for Ubuntu >= 18.04

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,9 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
 distro=$(lsb_release -si)
+version=$(lsb_release -sr)
 
 if [ "$distro" = "openSUSE" ]; then
     packages="npm nodejs"
+elif [ "$distro" = "Ubuntu" -a ${version:0:2} -ge 18 ]; then
+    packages="npm nodejs libgconf2-4"
 else
     packages="npm nodejs-legacy"
 fi


### PR DESCRIPTION
Fixes #521

"nodejs-legacy" becomes "nodejs" and "libgconf2-4" is added.

Use bash now instead of sh to do some version number parsing.