### PR TITLE
Extend error output

### DIFF
--- a/src/adb.js
+++ b/src/adb.js
@@ -156,8 +156,10 @@ var push = (file, dest, pushEvent) => {
   utils.platformToolsExec("adb", ["-P", PORT, "push", "\"" + file.replace('"','\"') + "\"", dest], (err, stdout, stderr) => {
     done=true;
     if (err !== null) {
-      pushEvent.emit("adbpush:error", err+" stdout: " + stdout.length > 50*1024 ? "overflow" : stdout + " stderr: " + stderr.length > 50*1024 ? "overflow" : stderr)
-      console.log(stdout.length > 50*1024 ? "overflow" : stdout + " stderr: " + stderr.length > 50*1024 ? "overflow" : stderr)
+      var stdoutShort = stdout && stdout.length > 50*1024 ? "[...]" + stdout.substr(-(50*1024 - 5), 50*1024 - 5) : stdout;
+      var stderrShort = stderr && stderr.length > 50*1024 ? "[...]" + stderr.substr(-(50*1024 - 5), 50*1024 - 5) : stderr;
+      pushEvent.emit("adbpush:error", err + ", stdout: " + stdoutShort + ", stderr: " + stderrShort);
+      console.log(stdoutShort + " stderr: " + stderrShort);
     }
     else pushEvent.emit("adbpush:end")
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -222,7 +222,7 @@ var checkPassword = (password, callback) => {
               // with password
               log.debug("unknown sudo error")
               callback(false, {
-                message: err.message.replace(password, "")
+                message: err.message.replace(password, "***")
               });
             }
         }else {
@@ -514,6 +514,14 @@ const getRandomInt = (min, max) => {
     return Math.floor(Math.random() * (max - min)) + min;
 }
 
+const hidePassword = (output, pw) => {
+  if (needRoot()) {
+    return output.replace(pw, "***");
+  } else {
+    return output;
+  }
+}
+
 module.exports = {
     setInstallDevice: setInstallDevice,
     setCustomPlatformTool: setCustomPlatformTool,
@@ -537,6 +545,7 @@ module.exports = {
     getPlatform: getPlatform,
     asarExec: asarExec,
     getRandomInt: getRandomInt,
-    getVersion: getVersion
+    getVersion: getVersion,
+    hidePassword: hidePassword
 //    decompressTarxzFileOnlyImages: decompressTarxzFileOnlyImages
 }


### PR DESCRIPTION
- add function "hidePw" to String prototype for convenience
- if stdout/stderr are too long, log last lines instead of "overflow"
- log additional commands
- add error logging where fastboot errors were silently ignored