### PR TITLE
Update `main.pug` with an improved expression `an usb` => `a USB`

### DIFF
--- a/src/html/scripts/main.pug
+++ b/src/html/scripts/main.pug
@@ -55,7 +55,7 @@ script.
      adb.start(false, false, (err) => {
          particles.hide();
          footer.topText.set("Waiting for device").append("<span id='wait-dot'>.</span>");
-         footer.underText.set("Please connect your device with an usb cable");
+         footer.underText.set("Please connect your device with a USB cable");
          if (process.platform === "win32")
            $('#windows-drivers-modal').modal('show');
          utils.getUpdateAvailable().then((updateAvailable) => {


### PR DESCRIPTION
Refer back to: https://www.ecenglish.com/learnenglish/when-use-a.

We also had this discussion in the [FluffyChat room](https://riot.im/app/#/room/!KzHjwnhdwaLkjewCCh:matrix.org/$15467341922186675gAlbR:matrix.org).