### PR TITLE
feat: install from data

### DIFF
--- a/src/devices.js
+++ b/src/devices.js
@@ -317,7 +317,8 @@ var install = (options) => {
         device: options.device,
         channel: options.channel,
         event: installEvent,
-        wipe: options.wipe
+        wipe: options.wipe,
+        ubuntuPushDir: options.data ? "/data/recovery/" : "/cache/recovery/"
       });
     });
     installEvent.on("system-image:done", () => {

--- a/src/html/modals/options.pug
+++ b/src/html/modals/options.pug
@@ -22,6 +22,10 @@
                 label
                   input#options-custom-tools(type='checkbox')
                   |  Custom tools
+              .col-xs-4
+                label
+                  input#options-data(type='checkbox')
+                  |  Install from data
               .col-xs-12
                 p#options-custom-tools-snap-note(hidden='hidden')
                   b NOTE:
@@ -29,7 +33,7 @@
               .col-xs-12
                 p#options-wipe-note(hidden='hidden')
                   b NOTE:
-                  |  If the wipe option is enabled all data stored on the device will be erased. 
+                  |  If the wipe option is enabled all data stored on the device will be erased.
                   b Please create an external backup of the data you want to keep!
             .div#options-custom-tools-area(hidden='hidden')
               .form-group

--- a/src/html/scripts/main.pug
+++ b/src/html/scripts/main.pug
@@ -140,7 +140,8 @@ script.
         installEvent = devices.install({
           device: global.installProperties.device,
           channel: global.installProperties.channel,
-          wipe: false  // TODO --wipe option
+          wipe: false,  // TODO --wipe option
+          data: false, // TODO --data option
         });
         setInstallEvents(installEvent);
         views.show("working", "particles");
@@ -180,7 +181,8 @@ script.
           installEvent = devices.install({
             device: output.device,
             channel: options.get("channel", true),
-            wipe: options.get("wipe", true)
+            wipe: options.get("wipe", true),
+            data: options.get("data", true),
           });
           setInstallEvents(installEvent);
         });

--- a/src/html/scripts/ui.pug
+++ b/src/html/scripts/ui.pug
@@ -3,6 +3,7 @@ script.
   const optionsVal = [
     {id: "channel", type: "select"},
     {id: "wipe", type: "checkbox", note: true},
+    {id: "data", type: "checkbox"},
     {id: "custom-tools", type: "checkbox"},
     {id: "custom-tools-adb", type: "input"},
     {id: "custom-tools-fastboot", type: "input"}

--- a/src/html/views/install.pug
+++ b/src/html/views/install.pug
@@ -19,5 +19,8 @@
         tr
           td Wipe
           td.user-wipe
+        tr
+          td Install from data
+          td.user-data
       button#btn-modal-options.btn.btn-default(type='button', style='width: 100%;', hidden='') Change options
       button#btn-inst.btn.btn-primary(type='button', style='width: 100%; margin-top: 10px;', hidden='') Install


### PR DESCRIPTION
This PR adds support to use `/data/recovery/` as `ubuntuPushDir`. Resolves issues with devices that have limited `/cache` partition size (#775 and also #618, #759, #798). This option is disabled by default.
