### PR TITLE
Do not mount all partitions

### DIFF
--- a/src/system-image.js
+++ b/src/system-image.js
@@ -53,10 +53,10 @@ var installLatestVersion = options => {
       }),
     adb
       .waitForDevice()
+      .then(() => adb.shell("mount -a || true"))
+      .then(() => utils.log.debug("adb mounted all partitions"))
       .then(() => adb.wipeCache())
       .then(() => utils.log.debug("adb wiped cache"))
-      .then(() => adb.shell("mount -a"))
-      .then(() => utils.log.debug("adb mounted recovery"))
       .then(() => adb.shell("mkdir -p /cache/recovery"))
       .then(() => {
         utils.log.debug("adb created /cache/recovery directory");


### PR DESCRIPTION
This hit me on angler: the main fstab has much more entries than what the recovery has as mountpoints, and also recovery does not mount many of the exotic partitions.

I think its finde not to mount anything here. The userdata, system and cache partitions will always be available. And thats the only things we should need.
