### PR TITLE
Wrap executable in double quotes, fixes #1451

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -117,7 +117,7 @@ function die(e) {
 let processes = [];
 function execTool(tool, args, callback) {
   let pid = cp.exec(
-    [getAndroidToolPath(tool), ...args].join(" "),
+    [`"${getAndroidToolPath(tool)}"`, ...args].join(" "),
     {
       maxBuffer: 1024 * 1024 * 2
     },


### PR DESCRIPTION
This should fix #1451 (and previously #847). This went unnoticed, because these paths only occur when the account is set up connected to a Microsoft account. The previous attempt (#1076) was abandoned, this one should be better.