### PR TITLE
Implement additional fastboot flags, resolves #1459

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2085,9 +2085,9 @@
       }
     },
     "electron": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.4.tgz",
-      "integrity": "sha512-5wiiGsif8jd1lS3Qhe9j8oQvUMnoWCvqBwYzzn+BGXGDq8aN8oTdM+j/2NY35Ktt3JrJdjKWcu9b7pDo8kNjbw==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.5.tgz",
+      "integrity": "sha512-fys/KnEfJq05TtMij+lFvLuKkuVH030CHYx03iZrW5DNNLwjE6cW3pysJ420lB0FRSfPjTHBMu2eVCf5TG71zQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -2096,9 +2096,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.0.tgz",
-          "integrity": "sha512-4BVAE9yp5DU3ISqBInsaRp9J474HWNaNVs8eZ1Far3dI1MwS3Wk0EvBRMM4xBh3Oz+c05hUgJmcbtAVmG8bv7w==",
+          "version": "12.19.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.1.tgz",
+          "integrity": "sha512-/xaVmBBjOGh55WCqumLAHXU9VhjGtmyTGqJzFBXRWZzByOXI5JAJNx9xPVGEsNizrNwcec92fQMj458MWfjN1A==",
           "dev": true
         }
       }
@@ -5756,9 +5756,12 @@
       }
     },
     "promise-android-tools": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-2.0.10.tgz",
-      "integrity": "sha512-WoiigUWIfzH2dulVs2Zv/N7o+z0PrtZbksFEYU1KphR8al+SjqITPbzoaoQl5Y7YnMBkjpZ3raKczBP0gBFEZQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-3.0.0.tgz",
+      "integrity": "sha512-XCYKjaDRs2Hsoh+gIMqTrYgBNcXbDAWQKQ4/Ij4etZEi/jMon/TxCE612bhouSO/uRoD1i+OENHbaw2rxIVaVg==",
+      "requires": {
+        "fs-extra": "^9.0.1"
+      }
     },
     "proto-list": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint-fix": "npm run lint -- --fix"
   },
   "devDependencies": {
-    "electron": "^10.1.4",
+    "electron": "^10.1.5",
     "electron-builder": "^22.9.1",
     "electron-packager": "^15.1.0",
     "eslint": "^6.7.2",
@@ -55,7 +55,7 @@
     "jquery-i18next": "^1.2.0",
     "popper.js": "^1.16.0",
     "progressive-downloader": "^1.0.5",
-    "promise-android-tools": "2.0.10",
+    "promise-android-tools": "^3.0.0",
     "ps-tree": "^1.2.0",
     "sudo-prompt": "^9.2.1",
     "system-image-node-module": "^1.1.1",

--- a/src/devices.js
+++ b/src/devices.js
@@ -33,7 +33,7 @@ function addPathToFiles(files, device) {
         files[i].file
       ),
       partition: files[i].partition,
-      force: files[i].force,
+      flags: files[i].flags,
       raw: files[i].raw
     });
   }


### PR DESCRIPTION
This adds promise-andorid-tools 3.0.0, thus resolving #1459. No config was using `--force`, so this does not break the API in a noticeable way.

The dependency update also includes prerequisites for backup and restore functionality (#141).