### PR TITLE
Make sure command gets evaluated on the device, resolves #1474

### DIFF
--- a/src/system-image.js
+++ b/src/system-image.js
@@ -53,7 +53,7 @@ var installLatestVersion = options => {
       }),
     adb
       .waitForDevice()
-      .then(() => adb.shell("mount -a || true"))
+      .then(() => adb.shell("'mount -a || true'"))
       .then(() => utils.log.debug("adb mounted all partitions"))
       .then(() => adb.wipeCache())
       .then(() => utils.log.debug("adb wiped cache"))


### PR DESCRIPTION
this ensures the command be evaluated on the device, which will always be a bourne shell