### PR TITLE
Permanent settings and better automatic reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2061,6 +2061,14 @@
         }
       }
     },
+    "doc-ready": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/doc-ready/-/doc-ready-1.0.4.tgz",
+      "integrity": "sha1-N/U5GWnP+ZQwP9/vLl1QNX+BZNM=",
+      "requires": {
+        "eventie": "^1"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2254,6 +2262,14 @@
             "yargs-parser": "^20.2.2"
           }
         }
+      }
+    },
+    "electron-dynamic-prompt": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/electron-dynamic-prompt/-/electron-dynamic-prompt-1.0.2.tgz",
+      "integrity": "sha512-w79vcwitHUVzuafAjwFMZg9NwAnRwnNY61g3slix9ZxPGU8uKr+T8wMlM/YwgNl6EUTV/50F4aiX60qiVMEYSQ==",
+      "requires": {
+        "doc-ready": "^1.0.4"
       }
     },
     "electron-notarize": {
@@ -2918,6 +2934,11 @@
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
       }
+    },
+    "eventie": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/eventie/-/eventie-1.0.6.tgz",
+      "integrity": "sha1-1P/IsMK15JPCqhsiy+kY067nRDc="
     },
     "expand-brackets": {
       "version": "2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -868,6 +868,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "atomically": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.6.0.tgz",
+      "integrity": "sha512-mu394MH+yY2TSKMyH+978PcGMZ8sRNks2PuVeH6c2ED4mimR2LEE039MVcIGVhtmG54cKEMh4gKhxKL/CLaX/w=="
+    },
     "author-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
@@ -1733,6 +1738,41 @@
         "typedarray": "^0.0.6"
       }
     },
+    "conf": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-7.1.2.tgz",
+      "integrity": "sha512-r8/HEoWPFn4CztjhMJaWNAe5n+gPUCSaJ0oufbqDLFKsA1V8JjAG7G+p0pgoDFAws9Bpk2VtVLLXqOBA7WxLeg==",
+      "requires": {
+        "ajv": "^6.12.2",
+        "atomically": "^1.3.1",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^5.2.0",
+        "env-paths": "^2.2.0",
+        "json-schema-typed": "^7.0.3",
+        "make-dir": "^3.1.0",
+        "onetime": "^5.1.0",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
+      }
+    },
     "config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -1824,6 +1864,21 @@
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
+      }
+    },
+    "debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "requires": {
+        "mimic-fn": "^3.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
+        }
       }
     },
     "debug": {
@@ -2025,7 +2080,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
       }
@@ -2477,6 +2531,22 @@
         }
       }
     },
+    "electron-store": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-6.0.1.tgz",
+      "integrity": "sha512-8rdM0XEmDGsLuZM2oRABzsLX+XmD5x3rwxPMEPv0MrN9/BWanyy3ilb2v+tCrKtIZVF3MxUiZ9Bfqe8e0popKQ==",
+      "requires": {
+        "conf": "^7.1.2",
+        "type-fest": "^0.16.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+          "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="
+        }
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -2503,6 +2573,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "env-paths": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3083,8 +3158,7 @@
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-      "dev": true
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -3095,8 +3169,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3184,6 +3257,14 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "requires": {
+        "locate-path": "^3.0.0"
       }
     },
     "findup-sync": {
@@ -4483,8 +4564,7 @@
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-path-inside": {
       "version": "3.0.2",
@@ -4657,8 +4737,12 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4860,6 +4944,15 @@
         }
       }
     },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
@@ -4915,7 +5008,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
@@ -4923,8 +5015,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -5054,8 +5145,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -5380,7 +5470,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -5436,6 +5525,27 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
       "version": "6.5.0",
@@ -5522,8 +5632,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5628,6 +5737,14 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "requires": {
+        "find-up": "^3.0.0"
       }
     },
     "plist": {
@@ -5814,8 +5931,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.0",
@@ -7402,7 +7518,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "axios": "^0.20.0",
     "bootstrap": "^3.3.7",
     "commander": "^2.9.0",
+    "electron-dynamic-prompt": "^1.0.2",
     "electron-open-link-in-browser": "^1.0.2",
     "electron-store": "^6.0.1",
     "form-data": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "bootstrap": "^3.3.7",
     "commander": "^2.9.0",
     "electron-open-link-in-browser": "^1.0.2",
+    "electron-store": "^6.0.1",
     "form-data": "^3.0.0",
     "fs-extra": "^9.0.1",
     "graphql": "^15.3.0",

--- a/src/main.js
+++ b/src/main.js
@@ -722,9 +722,10 @@ app.on("ready", function() {
           checked: settings.get("animations"),
           type: "checkbox",
           click: () => {
-            settings.set("animations", !settings.get("animations"));
-            if (settings.get("animations"))
+            if (settings.get("animations")) {
               mainWindow.webContents.send("animations:hide");
+            }
+            settings.set("animations", !settings.get("animations"));
           }
         },
         {

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -43,6 +43,7 @@ html
     include modals/options
     // medium prio
     include modals/unlock
+    include modals/result
     // high prio
     include modals/udev
     include modals/windows-drivers

--- a/src/pug/modals/result.pug
+++ b/src/pug/modals/result.pug
@@ -1,0 +1,25 @@
+#result-modal.modal.fade(tabindex='-1', role='dialog')
+  .modal-dialog(role='document')
+    .modal-content
+      .modal-header
+        button.close(type='button', data-dismiss='modal', aria-label='Close')
+          span(aria-hidden='true') ×
+        h4.modal-title Report your result
+      .modal-body
+        p To fix issues in the UBports Installer, it is vital that the developers recieve detailed feedback. To make this easier, the installer automates the reporting process. If you're interested in helping us make the UBports Installer better, keep reading! If not, click the button below and we will not bother you again.
+        p The UBports Community uses #[a(onclick="shell.openExternal('https://ubports.open-cuts.org/system/5e9d746c6346e112514cfec7')") OPEN-CUTS, the open crowdsourced user testing suite] to manage manual testing and #[a(onclick="shell.openExternal('https://github.com/ubports/ubports-installer/issues')") GitHub] to track bugs and feature requests for the UBports Installer. Since the installer developers rarely have access to all the devices the installer supports, it is vital for them to also recieve reports about what works.
+        p Select a result from the buttons below. You will see another window where you can explain your experience in more detail and modify all the data before submitting.
+        p Select the #[b PASS] option if everything worked as expected. If you experienced minor issues or annoyances, but finally succeeded in installing your device, select the #[b WONKY] result. The #[b FAIL] result indicates a more severe problem.
+      .modal-footer
+        button.btn.btn-default(type='button', data-dismiss='modal', onclick='ipcRenderer.invoke("setSettingsValue", "never.opencuts", true)') No, don't ask me again
+        button.btn.btn-success(type='button', data-dismiss='modal', onclick="report('PASS');") PASS
+        button.btn.btn-warning(type='button', data-dismiss='modal', onclick="report('WONKY');") WONKY
+        button.btn.btn-danger(type='button', data-dismiss='modal', onclick="report('FAIL');") FAIL
+  script.
+    function report(result) {
+      ipcRenderer.send("reportResult", result);
+    }
+
+    ipcRenderer.on("user:report", () => {
+      modals.show('result');
+    });

--- a/src/pug/modals/udev.pug
+++ b/src/pug/modals/udev.pug
@@ -12,9 +12,19 @@
           | Alternatively, you can choose to do this #[a(onclick="shell.openExternal('https://docs.ubports.com/en/latest/userguide/install.html#missing-udev-rules')") manually] through the command-line.
       .modal-footer
         button.btn.btn-default(type='button', data-dismiss='modal') Dismiss
-        button.btn.btn-default(type='button', data-dismiss='modal', onclick="localStorage.setItem('neverAskForUdevRules', 'true');") Don't ask me again
-        button.btn.btn-primary(type='button', data-dismiss='modal', onclick="localStorage.setItem('neverAskForUdevRules', 'true'); ipcRenderer.send('udev');") Set up rules automatically.
+        button.btn.btn-default(type='button', data-dismiss='modal', onclick='dismissUdev(false)') Don't ask me again
+        button.btn.btn-primary(type='button', data-dismiss='modal', onclick='dismissUdev(true)') Set up rules automatically.
   script.
-    if (process.platform === "linux" && !process.env.SNAP && !localStorage.getItem('neverAskForUdevRules')) {
-      setTimeout(() => modals.show('udev'), 1000);
+    function dismissUdev(set) {
+      ipcRenderer.invoke("setSettingsValue", "never.udev", true);
+      if (set) {
+        ipcRenderer.send("udev");
+      }
+    }
+    if (process.platform === "linux" && !process.env.SNAP) {
+      ipcRenderer.invoke("getSettingsValue", "never.udev")
+        .then(never =>
+          never ? null :
+          setTimeout(() => modals.show('udev'), 1000)
+        )
     }

--- a/src/pug/modals/windows-drivers.pug
+++ b/src/pug/modals/windows-drivers.pug
@@ -15,8 +15,15 @@
           | As a last resort, we also have #[a(onclick="shell.openExternal('https://devices.ubuntu-touch.io')") manual installation instructions for every device], that you can follow if you want to install without using the UBports Installer.
       .modal-footer
         button.btn.btn-default(type='button', data-dismiss='modal') Dismiss
-        button#btn-driver-never-ask.btn.btn-primary(type='button', data-dismiss='modal', onclick="localStorage.setItem('neverAskForWindowsDrivers', 'true');") Don't ask me again
+        button#btn-driver-never-ask.btn.btn-primary(type='button', data-dismiss='modal', onclick="dismissDrivers()") Don't ask me again
   script.
-    if (process.platform === "win32" && !localStorage.getItem('neverAskForWindowsDrivers')) {
-      setTimeout(() => modals.show('windows-drivers'), 1000);
+    function dismissDrivers() {
+      ipcRenderer.invoke("setSettingsValue", "never.windowsDrivers", true);
+    }
+    if (process.platform === "win32") {
+      ipcRenderer.invoke("getSettingsValue", "never.windowsDrivers")
+        .then(never =>
+          never ? null :
+          setTimeout(() => modals.show('windows-drivers'), 1000)
+        )
     }

--- a/src/pug/scripts/ui.js
+++ b/src/pug/scripts/ui.js
@@ -27,8 +27,8 @@ const animations = {
     $("#push-animation").hide();
     $("#download-animation").hide();
   },
-  particles: () => {
-    if (!localStorage.getItem("animationsDisabled")) {
+  particles: async () => {
+    if (await ipcRenderer.invoke("getSettingsValue", "animations")) {
       $("#particles-foreground").show();
       $("#particles-background").show();
       $("#push-animation").hide();
@@ -37,8 +37,8 @@ const animations = {
       animations.hideAll();
     }
   },
-  download: () => {
-    if (!localStorage.getItem("animationsDisabled")) {
+  download: async () => {
+    if (await ipcRenderer.invoke("getSettingsValue", "animations")) {
       $("#download-animation").show();
       $("#push-animation").hide();
       $("#particles-foreground").hide();
@@ -47,8 +47,8 @@ const animations = {
       animations.hideAll();
     }
   },
-  push: () => {
-    if (!localStorage.getItem("animationsDisabled")) {
+  push: async () => {
+    if (await ipcRenderer.invoke("getSettingsValue", "animations")) {
       $("#push-animation").show();
       $("#download-animation").hide();
       $("#particles-foreground").hide();
@@ -158,10 +158,5 @@ ipcRenderer.on("user:write:speed", (e, speed) => {
 });
 
 ipcRenderer.on("animations:hide", animations.hideAll);
-
-ipcRenderer.on("localstorage:set", (e, item, value) => {
-  if (value) localStorage.setItem(item, value);
-  else localStorage.removeItem(item);
-});
 
 views.show("working", "particles");

--- a/src/pug/scripts/ui.js
+++ b/src/pug/scripts/ui.js
@@ -130,7 +130,7 @@ const modals = {
 };
 
 $("#help").click(() => {
-  ipcRenderer.send("createBugReport");
+  modals.show("result");
 });
 
 $("#donate").click(() => {


### PR DESCRIPTION
- Replace LocalStorage with electron-store and add more settings options that use it to the global menu, resolves #694.
- Store OPEN-CUTS tokens and implement a UI for it (part of #1432).
- Fix #1476, where pasted logs were sometimes invalid
- Implement a UI to create bug reports, resolves #955.
- Unobtrusively ask users to report successful runs to OPEN-CUTS, resolves #1432.
- Improve "never ask again" functionality