### PR TITLE
Unpack libraries related to promise-android-tools

### DIFF
--- a/build.js
+++ b/build.js
@@ -80,6 +80,13 @@ var buildConfig = {
   asarUnpack: [
     // Unpack dependencies of pakcages containing binaries
     "node_modules/7zip-min/*", // for 7zip-bin
+    "node_modules/jsonfile/**/*", // for fs-extra
+    "node_modules/at-least-node/**/*", // for fs-extra
+    "node_modules/graceful-fs/**/*", // for fs-extra
+    "node_modules/universalify/**/*", // for fs-extra
+    "node_modules/fs-extra/**/*", // for promise-android-tools
+    "node_modules/cancelable-promise/**/*", // for promise-android-tools
+    "node_modules/promise-android-tools/**/*", // for android-tools-bin
     "node_modules/@babel/runtime/**/*" // for android-tools-bin
   ],
   extraMetadata: {

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,6 @@ const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 global.packageInfo = require("../package.json");
 
-const { DeviceTools } = require("promise-android-tools");
 const Api = require("ubports-api-node-module").Installer;
 const Store = require("electron-store");
 
@@ -57,6 +56,7 @@ const api = new Api({
   cachetime: 60000
 });
 global.api = api;
+const { DeviceTools } = require(utils.asarLibPathHack("promise-android-tools"));
 const deviceTools = new DeviceTools();
 global.deviceTools = deviceTools;
 global.adb = deviceTools.adb;


### PR DESCRIPTION
Since child_process.spawn() can not access files inside asar packages (https://github.com/electron/electron/issues/9459), we need to unpack a whole bunch of stuff. Super annoying. but this fixes #1517.