### PR TITLE
Improve android tools handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "jquery-i18next": "^1.2.0",
         "popper.js": "^1.16.0",
         "progressive-downloader": "^1.0.5",
-        "promise-android-tools": "^4.0.0",
+        "promise-android-tools": "^4.0.2",
         "ps-tree": "^1.2.0",
         "sudo-prompt": "^9.2.1",
         "system-image-node-module": "^1.1.1",
@@ -6704,9 +6704,10 @@
       }
     },
     "node_modules/promise-android-tools": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.0.tgz",
-      "integrity": "sha512-Xfl0UMIclfFDHf89/8nxbX0pXs6njNeX3DqEHLyneRlMDGSEQFze+h9haQB5G+a1UC33jztJkqobs9N6jfJgbQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.2.tgz",
+      "integrity": "sha512-3YZ/rmbmxTApekm9TkxuXqro0l9hKpAMwfcfJesoCOepW81mNkOg/Vn1eAsBoTHFMlRdOvD6FpKvURfCl7i1OA==",
+      "license": "GPL-3.0",
       "dependencies": {
         "android-tools-bin": "^1.0.4",
         "cancelable-promise": "^3.2.0",
@@ -14778,9 +14779,9 @@
       }
     },
     "promise-android-tools": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.0.tgz",
-      "integrity": "sha512-Xfl0UMIclfFDHf89/8nxbX0pXs6njNeX3DqEHLyneRlMDGSEQFze+h9haQB5G+a1UC33jztJkqobs9N6jfJgbQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.2.tgz",
+      "integrity": "sha512-3YZ/rmbmxTApekm9TkxuXqro0l9hKpAMwfcfJesoCOepW81mNkOg/Vn1eAsBoTHFMlRdOvD6FpKvURfCl7i1OA==",
       "requires": {
         "android-tools-bin": "^1.0.4",
         "cancelable-promise": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jquery-i18next": "^1.2.0",
     "popper.js": "^1.16.0",
     "progressive-downloader": "^1.0.5",
-    "promise-android-tools": "^4.0.0",
+    "promise-android-tools": "^4.0.2",
     "ps-tree": "^1.2.0",
     "sudo-prompt": "^9.2.1",
     "system-image-node-module": "^1.1.1",

--- a/src/devices.js
+++ b/src/devices.js
@@ -502,6 +502,8 @@ function assembleInstallSteps(steps) {
           function restartInstall() {
             install(steps);
           }
+          const smartRestart = step.resumable ? runStep : restartInstall;
+          let reconnections = 0;
           function runStep() {
             installStep(step)()
               .then(() => {
@@ -518,23 +520,40 @@ function assembleInstallSteps(steps) {
                   })()
                     .then(resolve)
                     .catch(reject);
-                } else if (
-                  step.type.includes("fastboot") &&
-                  error.message.includes("bootloader is locked")
-                ) {
-                  global.mainEvent.emit("user:oem-lock", runStep);
-                } else if (error.message.includes("low power")) {
+                } else if (error.message.includes("low battery")) {
                   global.mainEvent.emit("user:low-power");
                 } else if (
-                  error.message.includes("no device") ||
-                  error.message.includes("device offline") ||
-                  error.message.includes("No such device") ||
-                  error.message.includes("connection lost")
+                  error.message.includes("bootloader locked") ||
+                  error.message.includes("enable unlocking")
                 ) {
-                  mainEvent.emit(
-                    "user:connection-lost",
-                    step.resumable ? runStep : restartInstall
-                  );
+                  global.mainEvent.emit("user:oem-lock", runStep);
+                } else if (error.message.includes("no device")) {
+                  mainEvent.emit("user:connection-lost", smartRestart);
+                } else if (
+                  error.message.includes("device offline") ||
+                  error.message.includes("unauthorized")
+                ) {
+                  if (reconnections < 3) {
+                    adb
+                      .reconnect()
+                      .then(() => {
+                        utils.log.warn(
+                          `automatic reconnection ${++reconnections}`
+                        );
+                        runStep();
+                      })
+                      .catch(error => {
+                        utils.log.warn(
+                          `failed to reconnect automatically: ${error}`
+                        );
+                        mainEvent.emit("user:connection-lost", smartRestart);
+                      });
+                  } else {
+                    utils.log.warn(
+                      "maximum automatic reconnection attempts exceeded"
+                    );
+                    mainEvent.emit("user:connection-lost", smartRestart);
+                  }
                 } else if (error.message.includes("killed")) {
                   reject(); // Used for exiting the installer
                 } else {

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -38,8 +38,8 @@ html
     // --- Modals ---
     // low prio
     include modals/select-device
-    include modals/developer-mode
     include modals/oem-lock
+    include modals/developer-mode
     include modals/options
     // medium prio
     include modals/unlock

--- a/src/pug/modals/oem-lock.pug
+++ b/src/pug/modals/oem-lock.pug
@@ -4,23 +4,28 @@
       .modal-header
         button.close(type='button', data-dismiss='modal', aria-label='Close')
           span(aria-hidden='true') ×
-        h4#myModalLabel.modal-title Device locked
-      .modal-body
-        p
-          | Your device is oem locked, that means installation of third party operating systems like Ubuntu Touch is disabled.
-        b
-          | Removing the OEM-lock might void your device's warranty. If you want to be sure, please ask your manufacturer or vendor if they allow this. UBports is not responsible and won't replace devices in case of warranty loss. You are responsible for your own actions.
-        p
-          | Do you want to unlock your device now?
-        p
-          | You might see a confirmation dialog on your device next.
+        h4#oem-lock-label.modal-title Device locked
+      .modal-body#oem-lock-default
+        p Your device is oem locked, that means installation of third party operating systems like Ubuntu Touch is disabled.
+        b Removing the OEM-lock might void your device's warranty. If you want to be sure, please ask your manufacturer or vendor if they allow this. UBports is not responsible and won't replace devices in case of warranty loss. You are responsible for your own actions.
+        p Do you want to unlock your device now?
+        p You might see a confirmation dialog on your device next.
+      .modal-body#oem-lock-enable
+        p Your device could not be unlocked. Please make sure OEM unlocking is enabled in the devices' #[a(onclick="modals.show('developer-mode-info');") developer options]. After that, you can select the button below to continue the installation.
       .modal-footer
         button#btn-exit.btn.btn-default(type='button', data-dismiss='modal') Abort
         button#btn-unlock.btn.btn-primary(type='button') Unlock
         i#unlock-prog.fa.fa-cog.fa-spin.fa-2x.fa-fw.hidden(hidden='hidden')
   script.
-    ipcRenderer.on("user:oem-lock", (event) => {
+    ipcRenderer.on("user:oem-lock", (event, enable = false) => {
       modals.show('oem-lock');
+      if (enable) {
+        $("#oem-lock-default").hide();
+        $("#oem-lock-enable").show();
+      } else {
+        $("#oem-lock-default").show();
+        $("#oem-lock-enable").hide();
+      }
     });
 
     $("#btn-unlock").click(() => {

--- a/src/pug/modals/options.pug
+++ b/src/pug/modals/options.pug
@@ -1,4 +1,4 @@
-#options-modal.modal.fade(tabindex='-1', role='dialog')
+#options-modal.modal.fade(tabindex='-1', data-keyboard='false',  data-backdrop='static', role='dialog')
   .modal-dialog(role='document')
     .modal-content
       .modal-header

--- a/src/pug/views/select-os.pug
+++ b/src/pug/views/select-os.pug
@@ -4,10 +4,9 @@
       img(style='height: 350px; margin: auto; display: block;', src='../screens/Screen6.jpg')
     .col-xs-6(style='height: 100%')
       h4.user-install-header#device-name(style='font-weight: bold;')
-      p
-        | #[a#device-page-link about this device] | #[a#device-config view config file]
-      p
-        | What operating system do you want to install?
+      p #[a#device-page-link about this device] | #[a#device-config view config file]
+      p Please make sure you enabled #[a(onclick="modals.show('developer-mode-info')") developer mode and OEM unlocking].
+      p What operating system do you want to install?
       form.form-horizontal
         .form-group
           .col-xs-3


### PR DESCRIPTION
This upgrades to the latest point release of promise-android-tools, which fixes #1533, fixes #1506, and fixes #1498.
Fixes #1173 where it was possible to hide the config modal.
Fixes #983 and fixes #1317 where we could not reconnect to offline or unauthorized devices.
Handle some unlocking errors, part of #1479.