### PR TITLE
Only run release script once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
     branches: [ master ]
   release:
     types:
-      - created
       - published
 
 jobs:


### PR DESCRIPTION
We had a non-breaking race conditions where the upload fails on some artifacts and github actions sends out unnecessary emails due to this.