### PR TITLE
Move report.js to lib

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -9,7 +9,9 @@ const electron = {
     on: jest.fn(),
     handle: jest.fn()
   },
-  shell: jest.fn(),
+  shell: {
+    openExternal: jest.fn()
+  },
   Menu: jest.fn()
 };
 

--- a/__mocks__/open-cuts-reporter.js
+++ b/__mocks__/open-cuts-reporter.js
@@ -1,0 +1,7 @@
+const ubuntuPastebin = {
+  OpenCutsReporter: jest.fn().mockReturnValue({
+    smartRun: jest.fn()
+  })
+};
+
+module.exports = ubuntuPastebin;

--- a/__mocks__/ubuntu-pastebin.js
+++ b/__mocks__/ubuntu-pastebin.js
@@ -1,0 +1,5 @@
+const ubuntuPastebin = {
+  paste: jest.fn().mockResolvedValue("https://paste.ubuntu.com/asdf")
+};
+
+module.exports = ubuntuPastebin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,9 @@
         "electron-store": "^6.0.1",
         "form-data": "^3.0.0",
         "fs-extra": "^9.0.1",
-        "graphql": "^15.3.0",
-        "graphql-request": "^3.2.0",
         "jquery": "^3.5.0",
         "jquery-i18next": "^1.2.0",
+        "open-cuts-reporter": "^1.0.0",
         "popper.js": "^1.16.0",
         "progressive-downloader": "^1.0.5",
         "promise-android-tools": "^4.0.3",
@@ -29,6 +28,7 @@
         "system-image-node-module": "^1.1.2",
         "systeminformation": "^4.27.11",
         "ubports-api-node-module": "^3.0.2",
+        "ubuntu-pastebin": "^1.0.0",
         "winston": "^3.3.3"
       },
       "bin": {
@@ -1557,23 +1557,6 @@
         "node": ">=8.12.0"
       }
     },
-    "node_modules/app-builder-lib/node_modules/debug": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.0.tgz",
-      "integrity": "sha512-jjO6JD2rKfiZQnBoRzhRTbXjHLGLfH+UtGkWLc/UXAh/rzZMyjbgn0NcfFpqT8nd1kTtFnDiJcrIFkq4UKeJVg==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/append-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
@@ -2371,23 +2354,6 @@
       },
       "engines": {
         "node": ">=8.2.5"
-      }
-    },
-    "node_modules/builder-util/node_modules/debug": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.0.tgz",
-      "integrity": "sha512-jjO6JD2rKfiZQnBoRzhRTbXjHLGLfH+UtGkWLc/UXAh/rzZMyjbgn0NcfFpqT8nd1kTtFnDiJcrIFkq4UKeJVg==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/cache-base": {
@@ -3250,9 +3216,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -3566,9 +3532,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.5.tgz",
-      "integrity": "sha512-fys/KnEfJq05TtMij+lFvLuKkuVH030CHYx03iZrW5DNNLwjE6cW3pysJ420lB0FRSfPjTHBMu2eVCf5TG71zQ==",
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.6.tgz",
+      "integrity": "sha512-Wyiq5Fy64KAa51i72m+5zayYKSm9O5lnittUdaElAn3PAzGl3yDifYO2QsXR7k/iKxWVSROOPzf43mXYytL67Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -5075,9 +5041,9 @@
       }
     },
     "node_modules/galactus/node_modules/debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -5478,6 +5444,7 @@
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
       "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -9199,6 +9166,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/open-cuts-reporter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/open-cuts-reporter/-/open-cuts-reporter-1.0.0.tgz",
+      "integrity": "sha512-+CEK0k5+7IGcEK4hhU53DR+HJzOVRMfrqKpBeOn9T0RsmfUaE8uDbfbZnYGTwa1aSXDgl3DsXchpOsLFxaDang==",
+      "dependencies": {
+        "graphql-request": "^3.3.0"
+      }
+    },
     "node_modules/optimist": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
@@ -9264,12 +9239,15 @@
       }
     },
     "node_modules/p-each-series": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-      "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-finally": {
@@ -12281,6 +12259,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/ubuntu-pastebin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ubuntu-pastebin/-/ubuntu-pastebin-1.0.0.tgz",
+      "integrity": "sha512-Abi0JlPg4Ul2HCg8Gc0iTXMRiAhZ3m2qypvsvMBS6xM3wKgYimu4XXbEZTzuRutjwl0dBcnpKCxUF/S+yRiebw==",
+      "dependencies": {
+        "axios": "^0.20.0",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -14472,17 +14459,6 @@
         "sanitize-filename": "^1.6.3",
         "semver": "^7.3.2",
         "temp-file": "^3.3.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.0.tgz",
-          "integrity": "sha512-jjO6JD2rKfiZQnBoRzhRTbXjHLGLfH+UtGkWLc/UXAh/rzZMyjbgn0NcfFpqT8nd1kTtFnDiJcrIFkq4UKeJVg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "append-buffer": {
@@ -15114,17 +15090,6 @@
         "source-map-support": "^0.5.19",
         "stat-mode": "^1.0.0",
         "temp-file": "^3.3.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.0.tgz",
-          "integrity": "sha512-jjO6JD2rKfiZQnBoRzhRTbXjHLGLfH+UtGkWLc/UXAh/rzZMyjbgn0NcfFpqT8nd1kTtFnDiJcrIFkq4UKeJVg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "builder-util-runtime": {
@@ -15848,9 +15813,9 @@
       }
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -16098,9 +16063,9 @@
       }
     },
     "electron": {
-      "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.5.tgz",
-      "integrity": "sha512-fys/KnEfJq05TtMij+lFvLuKkuVH030CHYx03iZrW5DNNLwjE6cW3pysJ420lB0FRSfPjTHBMu2eVCf5TG71zQ==",
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.6.tgz",
+      "integrity": "sha512-Wyiq5Fy64KAa51i72m+5zayYKSm9O5lnittUdaElAn3PAzGl3yDifYO2QsXR7k/iKxWVSROOPzf43mXYytL67Q==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -17297,9 +17262,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -17623,7 +17588,8 @@
     "graphql": {
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
-      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA=="
+      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
+      "peer": true
     },
     "graphql-request": {
       "version": "3.3.0",
@@ -20565,6 +20531,14 @@
         }
       }
     },
+    "open-cuts-reporter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/open-cuts-reporter/-/open-cuts-reporter-1.0.0.tgz",
+      "integrity": "sha512-+CEK0k5+7IGcEK4hhU53DR+HJzOVRMfrqKpBeOn9T0RsmfUaE8uDbfbZnYGTwa1aSXDgl3DsXchpOsLFxaDang==",
+      "requires": {
+        "graphql-request": "^3.3.0"
+      }
+    },
     "optimist": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
@@ -20618,9 +20592,9 @@
       "dev": true
     },
     "p-each-series": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-      "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true
     },
     "p-finally": {
@@ -23058,6 +23032,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "ubuntu-pastebin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ubuntu-pastebin/-/ubuntu-pastebin-1.0.0.tgz",
+      "integrity": "sha512-Abi0JlPg4Ul2HCg8Gc0iTXMRiAhZ3m2qypvsvMBS6xM3wKgYimu4XXbEZTzuRutjwl0dBcnpKCxUF/S+yRiebw==",
+      "requires": {
+        "axios": "^0.20.0",
+        "form-data": "^3.0.0"
       }
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,9 @@
     "electron-store": "^6.0.1",
     "form-data": "^3.0.0",
     "fs-extra": "^9.0.1",
-    "graphql": "^15.3.0",
-    "graphql-request": "^3.2.0",
     "jquery": "^3.5.0",
     "jquery-i18next": "^1.2.0",
+    "open-cuts-reporter": "^1.0.0",
     "popper.js": "^1.16.0",
     "progressive-downloader": "^1.0.5",
     "promise-android-tools": "^4.0.3",
@@ -67,6 +66,7 @@
     "system-image-node-module": "^1.1.2",
     "systeminformation": "^4.27.11",
     "ubports-api-node-module": "^3.0.2",
+    "ubuntu-pastebin": "^1.0.0",
     "winston": "^3.3.3"
   }
 }

--- a/src/lib/report.js
+++ b/src/lib/report.js
@@ -18,11 +18,10 @@
  */
 
 const { shell } = require("electron");
-const util = require("util");
-const packageInfo = require("../package.json");
+const packageInfo = require("../../package.json");
 const { osInfo } = require("systeminformation");
-const { path: cachePath } = require("./lib/cache.js");
-const log = require("./lib/log.js");
+const { path: cachePath } = require("./cache.js");
+const log = require("./log.js");
 const { OpenCutsReporter } = require("open-cuts-reporter");
 const { paste } = require("ubuntu-pastebin");
 
@@ -46,7 +45,7 @@ function getDeviceString() {
  */
 function getTargetOsString() {
   try {
-    return !util.isUndefined(global.installProperties.osIndex)
+    return global.installProperties.osIndex === undefined
       ? global.installConfig.operating_systems[global.installProperties.osIndex]
           .name
       : "(target os not yet set)";

--- a/src/lib/report.spec.js
+++ b/src/lib/report.spec.js
@@ -1,0 +1,51 @@
+const log = require("./log.js");
+jest.mock("./log.js");
+const { OpenCutsReporter } = require("open-cuts-reporter");
+jest.mock("open-cuts-reporter");
+const { paste } = require("ubuntu-pastebin");
+jest.mock("ubuntu-pastebin");
+
+const {
+  sendOpenCutsRun,
+  sendBugReport,
+  prepareSuccessReport,
+  prepareErrorReport
+} = require("./report.js");
+
+describe("prepareErrorReport()", () => {
+  it("should return error report object", () => {
+    global.installProperties = { device: undefined };
+    expect(prepareErrorReport()).resolves.toBeDefined();
+  });
+});
+
+describe("prepareSuccessReport()", () => {
+  it("should return success report object", () => {
+    global.installProperties = {
+      device: "bacon"
+    };
+    expect(prepareSuccessReport()).resolves.toBeDefined();
+  });
+});
+
+describe("sendBugReport()", () => {
+  it("should send bug report", () => {
+    log.get.mockResolvedValue("log content");
+    expect(
+      sendBugReport({
+        title: "wasd"
+      })
+    ).resolves.toEqual(undefined);
+  });
+});
+
+describe("sendOpenCutsRun()", () => {
+  it("should send open-cuts run", () => {
+    log.get.mockResolvedValue("log content");
+    expect(
+      sendOpenCutsRun(null, {
+        result: "PASS"
+      })
+    ).resolves.toEqual(undefined);
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -45,7 +45,7 @@ const {
   sendBugReport,
   prepareSuccessReport,
   prepareErrorReport
-} = require("./report.js");
+} = require("./lib/report.js");
 const errors = require("./lib/errors.js");
 const devices = require("./devices.js");
 const prompt = require("electron-dynamic-prompt");


### PR DESCRIPTION
Separated out two new modules:

 - [ubuntu-pastebin](https://www.npmjs.com/package/ubuntu-pastebin)
 - [open-cuts-reporter](https://www.npmjs.com/package/open-cuts-reporter)

Also moved the reporting file to the lib directory and added some basic tests. This concludes the basics of the modularization refactoring and code cleanup. The plan is to get this out to QA and finalize the work in subsequent point releases.