### PR TITLE
Deprecate checksum strings in favor of checksum objects

### DIFF
--- a/src/devices.js
+++ b/src/devices.js
@@ -57,12 +57,6 @@ function installStep(step) {
         return download(
           step.files.map(file => ({
             ...file,
-            checksum:
-              file.checksum && file.checksum.sum && file.checksum.algorithm
-                ? file.checksum
-                : file.checksum
-                ? { sum: file.checksum, algorithm: "sha256" }
-                : null,
             partition: file.type,
             path: path.join(
               cachePath,


### PR DESCRIPTION
That hack is no longer required after https://github.com/ubports/installer-configs/pull/48 is merged.