### PR TITLE
plugins: manual_download: Resolve copyFile promise

### DIFF
--- a/src/core/plugins/core/plugin.js
+++ b/src/core/plugins/core/plugin.js
@@ -203,19 +203,21 @@ class CorePlugin extends Plugin {
             }, 10);
           })
             .then(downloadedFilePath =>
-              fs.ensureDir(
-                path.join(this.cachePath, this.props.config.codename, group)
-              ).then(() =>
-                fs.copyFile(
-                  downloadedFilePath,
-                  path.join(
-                    this.cachePath,
-                    this.props.config.codename,
-                    group,
-                    file.name
+              fs
+                .ensureDir(
+                  path.join(this.cachePath, this.props.config.codename, group)
+                )
+                .then(() =>
+                  fs.copyFile(
+                    downloadedFilePath,
+                    path.join(
+                      this.cachePath,
+                      this.props.config.codename,
+                      group,
+                      file.name
+                    )
                   )
                 )
-              )
             )
             .then(() =>
               checkFile(

--- a/src/core/plugins/core/plugin.js
+++ b/src/core/plugins/core/plugin.js
@@ -202,7 +202,7 @@ class CorePlugin extends Plugin {
               _event.emit("user:write:under", "Manual download required!");
             }, 10);
           })
-            .then(downloadedFilePath => {
+            .then(downloadedFilePath =>
               fs.ensureDir(
                 path.join(this.cachePath, this.props.config.codename, group)
               ).then(() =>
@@ -215,8 +215,8 @@ class CorePlugin extends Plugin {
                     file.name
                   )
                 )
-              );
-            })
+              )
+            )
             .then(() =>
               checkFile(
                 {


### PR DESCRIPTION
The whole block beginning with `.then(downloadedFilePath` and ending with `copyFile()` (^1) was never going to resolve its promise with an actual return value.
That meant that that `checkFile()` was being called before any of the promise functions inside the previous block had
the chance to run, therefore the copied file was not yet available, leading to checkFile trying to verify a non-existent path, leading to a checksum mismatch error.

Solution is to make the whole block return something, in this case the value of the last chained promise.

Solves:
```
error: Error: core:manual_download: Error: checksum mismatch
```

Fixes https://github.com/ubports/ubports-installer/issues/1754

^1:
https://github.com/ubports/ubports-installer/blob/95745e519351adc3189e7e285a553bc6c1e5100a/src/core/plugins/core/plugin.js#L205-L219