### PR TITLE
Download rename

### DIFF
--- a/src/core/helpers/asarLibs.js
+++ b/src/core/helpers/asarLibs.js
@@ -29,7 +29,7 @@ const packageInfo = require("../../../package.json");
  */
 function asarLibPathHack(lib) {
   return packageInfo.package
-    ? path.join(__dirname, "../../../app.asar.unpacked/node_modules/", lib)
+    ? path.join(__dirname, "../../../../app.asar.unpacked/node_modules/", lib)
     : lib;
 }
 

--- a/src/core/plugins/core/plugin.js
+++ b/src/core/plugins/core/plugin.js
@@ -121,7 +121,7 @@ class CorePlugin extends Plugin {
           this.cachePath,
           this.props.config.codename,
           group,
-          path.basename(file.url)
+          file.name || path.basename(file.url)
         )
       })),
       (progress, speed) => {
@@ -130,8 +130,9 @@ class CorePlugin extends Plugin {
         this.event.emit("user:write:under", "Downloading");
       },
       (current, total) => {
-        if (current > 1)
+        if (current > 0)
           this.log.info(`Downloaded file ${current} of ${total}`);
+        else this.log.info(`Downloading ${total} files`);
         this.event.emit(
           "user:write:status",
           `${current} of ${total} files downloaded and verified`,

--- a/src/core/plugins/core/plugin.js
+++ b/src/core/plugins/core/plugin.js
@@ -208,6 +208,11 @@ class CorePlugin extends Plugin {
       );
   }
 
+  /**
+   * core:manual_download action
+   * @param {Object} param0 {group, file}
+   * @returns {Promise}
+   */
   action__manual_download({ group, file }) {
     return Promise.resolve()
       .then(() => {

--- a/src/core/plugins/core/plugin.spec.js
+++ b/src/core/plugins/core/plugin.spec.js
@@ -143,7 +143,7 @@ describe("core plugin", () => {
       download.mockRejectedValueOnce("download error");
       core
         .action__download({
-          group: "fimrware",
+          group: "firmware",
           files: [
             { url: "a/c", checksum: { sum: "b", algorithm: "sha256" } },
             { url: "a/b", checksum: { sum: "a", algorithm: "sha256" } }

--- a/src/core/plugins/core/plugin.spec.js
+++ b/src/core/plugins/core/plugin.spec.js
@@ -148,11 +148,18 @@ describe("core plugin", () => {
             [
               {
                 checksum: { algorithm: "sha256", sum: "b" },
-                path: "a/yggdrasil/firmware/c",
+                path: expect.stringMatching(/a.yggdrasil.firmware.c/),
                 url: "a/c"
               },
-              { path: "a/yggdrasil/firmware/b", url: "a/b" },
-              { name: "d", path: "a/yggdrasil/firmware/d", url: "a/c" }
+              {
+                path: expect.stringMatching(/a.yggdrasil.firmware.b/),
+                url: "a/b"
+              },
+              {
+                name: "d",
+                path: expect.stringMatching(/a.yggdrasil.firmware.d/),
+                url: "a/c"
+              }
             ],
             expect.any(Function),
             expect.any(Function),

--- a/src/core/plugins/core/plugin.spec.js
+++ b/src/core/plugins/core/plugin.spec.js
@@ -132,13 +132,34 @@ describe("core plugin", () => {
 
   describe("action__download()", () => {
     it("should download", () =>
-      core.action__download({
-        group: "fimrware",
-        files: [
-          { url: "a/c", checksum: { sum: "b", algorithm: "sha256" } },
-          { url: "a/b", checksum: { sum: "a", algorithm: "sha256" } }
-        ]
-      })); // TODO add assertions for event messages
+      core
+        .action__download({
+          group: "firmware",
+          files: [
+            { url: "a/c", checksum: { sum: "b", algorithm: "sha256" } },
+            { url: "a/b" },
+            { url: "a/c", name: "d" }
+          ]
+        })
+        .then(r => {
+          expect(r).toEqual(undefined);
+          expect(download).toHaveBeenCalledTimes(1);
+          expect(download).toHaveBeenCalledWith(
+            [
+              {
+                checksum: { algorithm: "sha256", sum: "b" },
+                path: "a/yggdrasil/firmware/c",
+                url: "a/c"
+              },
+              { path: "a/yggdrasil/firmware/b", url: "a/b" },
+              { name: "d", path: "a/yggdrasil/firmware/d", url: "a/c" }
+            ],
+            expect.any(Function),
+            expect.any(Function),
+            expect.any(Function)
+          );
+          expect(mainEvent.emit).toHaveBeenCalledTimes(20);
+        }));
     it("should show network error", done => {
       download.mockRejectedValueOnce("download error");
       core


### PR DESCRIPTION
This enables adding a `name` property to file objects in the `core:download` action. Also see https://github.com/ubports/installer-configs/pull/84. Resolves #1611.

cc @Vince1171