### PR TITLE
adds Fedora to setup-dev.sh

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -19,6 +19,14 @@ case "${distro}" in
             packages="npm nodejs libgconf2-4"
         fi
         ;;
+    "Fedora")
+        if [[ ${version} -ge 18 ]]; then
+            packageCommand="dnf install"
+        else
+            packageCommand="yum install"
+        fi
+        packages="npm nodejs"
+        ;;
     "*")
         packages="npm nodejs-legacy"
         echo "Distro could not be identified. Please add yours to the script."


### PR DESCRIPTION
Adds install options for Fedora Linux. 

Only tested on Fedora 33, and the version where `yum` is replaced by `dnf` comes from here:https://github.com/rpm-software-management/dnf#installing

To verify the installation was working I ran:
```
$ npm start -- -h

> ubports-installer@0.8.9-beta start /home/ccastro/Projetos/ubports-installer
> npm run prerender && electron . "-h"


> ubports-installer@0.8.9-beta prerender
> npx gulp pug

[18:10:13] Using gulpfile ~/Projetos/ubports-installer/gulpfile.js
[18:10:13] Starting 'pug'...
[18:10:15] Finished 'pug' after 1.51 s
Usage: npm start -- [-f <file>] [-v[v] [-d]

UBports Installer (0.8.9-beta) source for linux
GPL-3.0 UBports Foundation <info@ubports.com>
The easy way to install Ubuntu Touch on UBports devices. A friendly cross-platform Installer for Ubuntu Touch. Just connect a supported device to your PC, follow the on-screen instructions and watch this awesome tool do all the rest.
https://devices.ubuntu-touch.io

Options:
  -V, --version      output the version number
  -f, --file <file>  Override the official config by loading a YAML local file
  -v, --verbose      Print debugging information. Multiple -v options increase
                     the verbosity
  -d, --debug        Enable electron's web debugger to inspect the frontend
  -h, --help         display help for command
```