### PR TITLE
Implement additional fastboot actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "graphql": "^15.6.0",
         "open-cuts-reporter": "^1.0.2",
         "progressive-downloader": "^1.0.7",
-        "promise-android-tools": "^4.0.6",
+        "promise-android-tools": "^4.0.8",
         "ps-tree": "^1.2.0",
         "sudo-prompt": "^9.2.1",
         "svelte-markdown": "^0.2.2",
@@ -7907,33 +7907,19 @@
       }
     },
     "node_modules/promise-android-tools": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.6.tgz",
-      "integrity": "sha512-ZH4nCpB7pSr+kwFTwU3hq/X826PdhBEV2YGsdzyfeHchNmtK9bB0E0kbJ3BxveSnxN/0+4zRf3e8ian4rV0dWw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.8.tgz",
+      "integrity": "sha512-NyPSUEW+VKrt94FsexbJoR4J56kaJiv5MhTlSndqVKXoMNfxmNAQ0MQ453syLxGizzrqVC2kFu+D1mEC4ghiew==",
       "dependencies": {
         "android-tools-bin": "^1.0.5",
         "cancelable-promise": "^3.2.3",
-        "fs-extra": "^9.1.0"
+        "fs-extra": "^10.0.0"
       }
     },
     "node_modules/promise-android-tools/node_modules/cancelable-promise": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-3.2.3.tgz",
       "integrity": "sha512-P0yW/pq7ZEx4znOnDd4PqA5l+I/INpo32BE4Rg3QQxVBhKk7g9hAbmJt7oYbffo1q8j+1QfSZHGmjHMqj8RoJw=="
-    },
-    "node_modules/promise-android-tools/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -16620,30 +16606,19 @@
       }
     },
     "promise-android-tools": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.6.tgz",
-      "integrity": "sha512-ZH4nCpB7pSr+kwFTwU3hq/X826PdhBEV2YGsdzyfeHchNmtK9bB0E0kbJ3BxveSnxN/0+4zRf3e8ian4rV0dWw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.8.tgz",
+      "integrity": "sha512-NyPSUEW+VKrt94FsexbJoR4J56kaJiv5MhTlSndqVKXoMNfxmNAQ0MQ453syLxGizzrqVC2kFu+D1mEC4ghiew==",
       "requires": {
         "android-tools-bin": "^1.0.5",
         "cancelable-promise": "^3.2.3",
-        "fs-extra": "^9.1.0"
+        "fs-extra": "^10.0.0"
       },
       "dependencies": {
         "cancelable-promise": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-3.2.3.tgz",
           "integrity": "sha512-P0yW/pq7ZEx4znOnDd4PqA5l+I/INpo32BE4Rg3QQxVBhKk7g9hAbmJt7oYbffo1q8j+1QfSZHGmjHMqj8RoJw=="
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "graphql": "^15.6.0",
     "open-cuts-reporter": "^1.0.2",
     "progressive-downloader": "^1.0.7",
-    "promise-android-tools": "^4.0.6",
+    "promise-android-tools": "^4.0.8",
     "ps-tree": "^1.2.0",
     "sudo-prompt": "^9.2.1",
     "svelte-markdown": "^0.2.2",

--- a/src/core/plugins/fastboot/plugin.js
+++ b/src/core/plugins/fastboot/plugin.js
@@ -113,6 +113,32 @@ class FastbootPlugin extends Plugin {
   }
 
   /**
+   * fastboot:reboot_fastboot action
+   * @returns {Promise}
+   */
+  action__reboot_fastboot() {
+    return Promise.resolve().then(() => {
+      this.event.emit("user:write:working", "particles");
+      this.event.emit("user:write:status", "Rebooting", true);
+      this.event.emit("user:write:under", "Rebooting to fastbootd");
+      return this.fastboot.rebootFastboot();
+    });
+  }
+
+  /**
+   * fastboot:reboot_recovery action
+   * @returns {Promise}
+   */
+  action__reboot_recovery() {
+    return Promise.resolve().then(() => {
+      this.event.emit("user:write:working", "particles");
+      this.event.emit("user:write:status", "Rebooting", true);
+      this.event.emit("user:write:under", "Rebooting to recovery");
+      return this.fastboot.rebootRecovery();
+    });
+  }
+
+  /**
    * fastboot:reboot action
    * @returns {Promise}
    */

--- a/src/core/plugins/fastboot/plugin.js
+++ b/src/core/plugins/fastboot/plugin.js
@@ -210,6 +210,29 @@ class FastbootPlugin extends Plugin {
   }
 
   /**
+   * fastboot:wipe_super action
+   * @returns {Promise}
+   */
+  action__wipe_super({ image }) {
+    return Promise.resolve().then(() => {
+      this.event.emit("user:write:working", "circuit");
+      this.event.emit("user:write:status", "Wiping super", true);
+      this.event.emit(
+        "user:write:under",
+        "Wiping and repartitioning super partition using fastbootd"
+      );
+      return this.fastboot.wipeSuper(
+        path.join(
+          this.cachePath,
+          this.props.config.codename,
+          image.group,
+          image.file
+        )
+      );
+    });
+  }
+
+  /**
    * fastboot:erase action
    * @returns {Promise}
    */


### PR DESCRIPTION
Devices, which are launching with Android 10 and higher, are required to implement [Dynamic Partitions](https://source.android.com/devices/tech/ota/dynamic_partitions/implement).

This requires a different workflow when installing, such as resizing super partitions or rebooting to userspace fastboot ([fastbootd](https://source.android.com/devices/bootloader/fastbootd)) mode to flash logical partitions located withing the physical super partition.

This PR bumps `promise-android-tools` to 4.0.8, which supports additional fastboot commands, and wires up new actions to be used by device specific installer configs, like:

### Reboot to fastbootd mode via fastboot
```
- fastboot:reboot_fastboot:
```

### Reboot to recovery via fastboot
```
- fastboot:reboot_recovery:
```

### Wipe super partitions and repartition with specified super.img
```
- fastboot:wipe_super:
    image:
        file: "super_empty.img"
        group: "firmware"
```