### PR TITLE
Fixes for building, typo and windows ci

### DIFF
--- a/__mocks__/systeminformation.js
+++ b/__mocks__/systeminformation.js
@@ -1,0 +1,14 @@
+function osInfo(cb) {
+  cb({
+    distro: "distro",
+    release: "release",
+    codename: "codename",
+    platform: "platform",
+    kernel: "kernel",
+    arch: "arch",
+    build: "build",
+    servicepack: "servicepack"
+  });
+}
+
+module.exports.osInfo = osInfo;

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -40,7 +40,8 @@ export default {
     sourcemap: true,
     format: "iife",
     name: "app",
-    file: "public/build/bundle.js"
+    file: "public/build/bundle.js",
+    inlineDynamicImports: true
   },
   plugins: [
     svelte({

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -93,7 +93,7 @@
     push("/working");
     footerData.set({
       topText: `${$installConfigData.name} (${$installConfigData.codename})`,
-      underText: "Please Configure the installation",
+      underText: "Please configure the installation",
       waitingDots: false
     });
     yumi.setPosition("center");

--- a/src/lib/reporter.spec.js
+++ b/src/lib/reporter.spec.js
@@ -6,6 +6,8 @@ const { prompt } = require("./prompt.js");
 jest.mock("./prompt.js");
 const { OpenCutsReporter } = require("open-cuts-reporter");
 jest.mock("open-cuts-reporter");
+const { osInfo } = require("systeminformation");
+jest.mock("systeminformation");
 
 const reporter = require("./reporter.js");
 


### PR DESCRIPTION
The `getEnvironment` call is very slow on windows, causing the tests on windows to time out and fail the test suite.

There is also a change to rollup to fix build breakage because of code splitting attempts.

Also fix a case typo.