### PR TITLE
ui: PromptModals: fix checkboxes

### DIFF
--- a/src/ui/modals/specific-modals/PromptModals.svelte
+++ b/src/ui/modals/specific-modals/PromptModals.svelte
@@ -57,8 +57,7 @@
               <input
                 class="form-check-input"
                 type="checkbox"
-                bind:value={formData[id][field.var]}
-                checked={field.value}
+                bind:checked={formData[id][field.var]}
               />
             {:else if field.type === "text"}
               <input


### PR DESCRIPTION
We need to bind to checked state instead of value, see:
  - https://svelte.dev/tutorial/checkbox-inputs

Issue: https://github.com/ubports/ubports-installer/issues/2494