### PR TITLE
Bring back pasted log files in bug reports

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -1,5 +1,6 @@
 const axios = {
   get: jest.fn().mockResolvedValue(),
+  post: jest.fn().mockResolvedValue(),
   create: jest.fn()
 };
 

--- a/src/lib/paste.js
+++ b/src/lib/paste.js
@@ -1,0 +1,53 @@
+"use strict";
+
+/*
+ * Copyright (C) 2022 UBports Foundation <info@ubports.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const axios = require("axios");
+
+/**
+ * paste stuff
+ */
+class Paste {
+  /**
+   * send paste
+   * @async
+   * @returns {String} url of the paste
+   */
+  async paste(logfile) {
+    return axios
+      .post(
+        "https://snip.hxrsh.in/api/snip/new",
+        {
+          content: await logfile,
+          slug: `ubi-${new Date().getTime()}`,
+          language: "text"
+        },
+        {
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      )
+      .then(({ data }) =>
+        data.slug ? `https://snip.hxrsh.in/${data.slug}` : null
+      )
+      .catch(() => null);
+  }
+}
+
+module.exports = new Paste();

--- a/src/lib/paste.spec.js
+++ b/src/lib/paste.spec.js
@@ -1,0 +1,24 @@
+process.argv = [null, null, "-vv"];
+const axios = require("axios");
+jest.mock("axios");
+axios.create.mockReturnValue(axios);
+const { paste } = require("./paste.js");
+
+it("should be a singleton", () => {
+  expect(require("./paste.js")).toBe(require("./paste.js"));
+});
+
+describe("paste()", () => {
+  it("should return paste url", () => {
+    axios.post.mockResolvedValueOnce({ data: { slug: "asdf" } });
+    expect(paste()).resolves.toBe("https://snip.hxrsh.in/asdf");
+  });
+  it("should return null if slug missing", () => {
+    axios.post.mockResolvedValueOnce({ data: {} });
+    expect(paste()).resolves.toBe(null);
+  });
+  it("should return null on error", () => {
+    axios.post.mockRejectedValueOnce();
+    expect(paste()).resolves.toBe(null);
+  });
+});

--- a/src/lib/reporter.spec.js
+++ b/src/lib/reporter.spec.js
@@ -1,6 +1,8 @@
 process.argv = [null, null, "-vv"];
 const log = require("./log.js");
 jest.mock("./log.js");
+const { paste } = require("./paste.js");
+jest.mock("./paste.js");
 const settings = require("./settings.js");
 const { prompt } = require("./prompt.js");
 jest.mock("./prompt.js");


### PR DESCRIPTION
In case OPEN-CUTS fails, we can still look at the paste this way. Works using [SnipBin](https://snip.hxrsh.in/api-docs.md), since ubuntu pastebin does not allow anonymous pastes any more.