### PR TITLE
Show hidden systemimage channels

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -24,6 +24,7 @@ const YAML = require("yaml");
 const mainEvent = require("../lib/mainEvent.js");
 const { path: cachePath } = require("../lib/cache.js");
 const log = require("../lib/log.js");
+const settings = require("../lib/settings.js");
 const errors = require("../lib/errors.js");
 const window = require("../lib/window.js");
 const api = require("./helpers/api.js");
@@ -46,7 +47,13 @@ class Core {
   constructor() {
     this.props = {};
     this.reset();
-    this.plugins = new PluginIndex(this.props, cachePath, mainEvent, log);
+    this.plugins = new PluginIndex(
+      this.props,
+      cachePath,
+      mainEvent,
+      log,
+      settings
+    );
   }
 
   /**

--- a/src/core/plugins/index.js
+++ b/src/core/plugins/index.js
@@ -40,11 +40,12 @@ const SystemimagePlugin = require("./systemimage/plugin.js");
  * @property {SystemimagePlugin} plugins.systemimage systemimage plugin
  */
 class PluginIndex {
-  constructor(props, cachePath, mainEvent, log) {
+  constructor(props, cachePath, mainEvent, log, settings) {
     this.props = props;
     this.log = log;
+    this.settings = settings;
     this.event = mainEvent;
-    const pluginArgs = [props, cachePath, this.event, log];
+    const pluginArgs = [props, cachePath, this.event, log, settings];
     this.plugins = {
       adb: new AdbPlugin(...pluginArgs),
       asteroid_os: new AsteroidOsPlugin(...pluginArgs),

--- a/src/core/plugins/index.spec.js
+++ b/src/core/plugins/index.spec.js
@@ -7,7 +7,9 @@ const log = {
   error: jest.fn()
 };
 
-const pluginArgs = [{}, "a", {}, log];
+const settings = {};
+
+const pluginArgs = [{}, "a", {}, log, settings];
 
 const pluginIndex = new (require("./index.js"))(...pluginArgs);
 const originalPluginList = pluginIndex.plugins;

--- a/src/core/plugins/plugin.js
+++ b/src/core/plugins/plugin.js
@@ -34,12 +34,14 @@ class Plugin {
    * @param {String} cachePath cache path
    * @param {EventEmitter} event event
    * @param {Object} log logger
+   * @param {Object} settings settings manager
    */
-  constructor(props, cachePath, event, log) {
+  constructor(props, cachePath, event, log, settings) {
     this.props = props;
     this.cachePath = cachePath;
     this.event = event;
     this.log = log;
+    this.settings = settings;
   }
 
   /**

--- a/src/core/plugins/systemimage/api.js
+++ b/src/core/plugins/systemimage/api.js
@@ -99,13 +99,17 @@ const getChannels = device =>
             !(
               (
                 !properties ||
-                properties.hidden ||
                 properties.redirect ||
+                (properties.alias && properties.hidden) ||
                 !properties.devices
               ) // remove invalid channels
             ) && properties.devices[device] // remove channels that don't serve this device
         )
-        .map(([name]) => name)
+        .map(([name, properties]) => ({
+          value: name,
+          label: name.replace("ubports-touch/", ""),
+          hidden: properties.hidden || false
+        }))
     );
 
 module.exports = { getImages, getChannels };

--- a/src/core/plugins/systemimage/api.spec.js
+++ b/src/core/plugins/systemimage/api.spec.js
@@ -113,15 +113,31 @@ unmount system",
       it("should resolve channels", () => {
         axios.get.mockResolvedValue({
           data: {
-            "16.04/stable": { devices: { bacon: "a" } },
+            "ubports-touch/16.04/stable": { devices: { bacon: "a" } },
+            "16.04/stable": {
+              devices: { bacon: "a" },
+              hidden: true,
+              alias: "ubports-touch/16.04/stable"
+            },
             "17.04/stable": { devices: { bacon: "a" }, hidden: true },
             "18.04/stable": { devices: { bacon: "a" }, redirect: "asdf" },
             "19.04/stable": { devices: { hamburger: "a" } }
           }
         });
-        return api
-          .getChannels("bacon")
-          .then(r => expect(r).toEqual(["16.04/stable"]));
+        return api.getChannels("bacon").then(r =>
+          expect(r).toEqual([
+            {
+              hidden: false,
+              label: "16.04/stable",
+              value: "ubports-touch/16.04/stable"
+            },
+            {
+              hidden: true,
+              label: "17.04/stable",
+              value: "17.04/stable"
+            }
+          ])
+        );
       });
     });
   });

--- a/src/core/plugins/systemimage/plugin.js
+++ b/src/core/plugins/systemimage/plugin.js
@@ -82,7 +82,9 @@ class SystemimagePlugin extends Plugin {
       .getChannels(this.props.config.codename)
       .then(channels => ({
         visible: channels.filter(({ hidden }) => !hidden).reverse(),
-        hidden: channels.filter(({ hidden }) => hidden)
+        hidden: this.settings.get("systemimage.showHiddenChannels")
+          ? channels.filter(({ hidden }) => hidden)
+          : []
       }))
       .then(({ visible, hidden }) => [
         ...visible.map(({ value, label }) => ({ value, label })),

--- a/src/core/plugins/systemimage/plugin.js
+++ b/src/core/plugins/systemimage/plugin.js
@@ -78,14 +78,19 @@ class SystemimagePlugin extends Plugin {
    * @returns {Promise<Array<Object>>}
    */
   remote_values__channels() {
-    return api.getChannels(this.props.config.codename).then(channels =>
-      channels
-        .map(channel => ({
-          value: channel,
-          label: channel.replace("ubports-touch/", "")
-        }))
-        .reverse()
-    );
+    return api
+      .getChannels(this.props.config.codename)
+      .then(channels => ({
+        visible: channels.filter(({ hidden }) => !hidden).reverse(),
+        hidden: channels.filter(({ hidden }) => hidden)
+      }))
+      .then(({ visible, hidden }) => [
+        ...visible.map(({ value, label }) => ({ value, label })),
+        ...(hidden.length
+          ? [{ label: "--- hidden channels ---", disabled: true }]
+          : []),
+        ...hidden.map(({ value, label }) => ({ value, label }))
+      ]);
   }
 }
 

--- a/src/core/plugins/systemimage/plugin.spec.js
+++ b/src/core/plugins/systemimage/plugin.spec.js
@@ -4,10 +4,6 @@ api.getImages.mockResolvedValue({
   files: [{ url: "a/s/d/f" }],
   commands: "here be dragons"
 });
-api.getChannels.mockResolvedValue([
-  "ubports-touch/16.04/devel",
-  "ubports-touch/16.04/stable"
-]);
 const systemimage = new (require("./plugin.js"))({
   os: { name: "Ubuntu Touch" },
   config: { codename: "bacon" },
@@ -50,13 +46,43 @@ describe("systemimage plugin", () => {
   });
   describe("remote_values", () => {
     describe("channels", () => {
-      it("should resolve channels", () =>
+      it("should resolve channels", () => {
+        api.getChannels.mockResolvedValueOnce([
+          {
+            hidden: false,
+            label: "16.04/stable",
+            value: "ubports-touch/16.04/stable"
+          },
+          {
+            hidden: true,
+            label: "17.04/stable",
+            value: "17.04/stable"
+          }
+        ]);
         systemimage.remote_values__channels().then(r =>
           expect(r).toEqual([
             { label: "16.04/stable", value: "ubports-touch/16.04/stable" },
-            { label: "16.04/devel", value: "ubports-touch/16.04/devel" }
+            { label: "--- hidden channels ---", disabled: true },
+            { label: "17.04/stable", value: "17.04/stable" }
           ])
-        ));
+        );
+      });
+      it("should not include hidden channels separator if none specified", () => {
+        api.getChannels.mockResolvedValueOnce([
+          {
+            hidden: false,
+            label: "16.04/stable",
+            value: "ubports-touch/16.04/stable"
+          }
+        ]);
+        systemimage
+          .remote_values__channels()
+          .then(r =>
+            expect(r).toEqual([
+              { label: "16.04/stable", value: "ubports-touch/16.04/stable" }
+            ])
+          );
+      });
     });
   });
 });

--- a/src/lib/menuManager.js
+++ b/src/lib/menuManager.js
@@ -139,6 +139,16 @@ class MenuManager {
             }
           },
           {
+            label: "Show hidden System-Image Channels",
+            checked: settings.get("systemimage.showHiddenChannels"),
+            type: "checkbox",
+            click: () =>
+              settings.set(
+                "systemimage.showHiddenChannels",
+                !settings.get("systemimage.showHiddenChannels")
+              )
+          },
+          {
             label: "Never ask for udev rules",
             checked: settings.get("never.udev"),
             visible:

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -45,6 +45,12 @@ const settings = new Store({
         type: "boolean",
         default: false
       }
+    },
+    systemimage: {
+      showHiddenChannels: {
+        type: "boolean",
+        default: false
+      }
     }
   }
 });

--- a/src/ui/modals/specific-modals/PromptModals.svelte
+++ b/src/ui/modals/specific-modals/PromptModals.svelte
@@ -50,7 +50,9 @@
             {#if field.type === "select"}
               <select class="form-select" bind:value={formData[id][field.var]}>
                 {#each field.values as value}
-                  <option value={value.value}>{value.label}</option>
+                  <option disabled={value.disabled} value={value.value}
+                    >{value.label}</option
+                  >
                 {/each}
               </select>
             {:else if field.type === "checkbox"}


### PR DESCRIPTION
hidden channels are presented in a separate section at the end of the dropdown.
Replaces #2432, thanks to @mariogrip for the idea.
![Screenshot at 2022-03-16 14-13-59](https://user-images.githubusercontent.com/12068939/158603639-57285f0c-7100-4c4d-99cb-1ebe9b9f5d2c.png)
