### PR TITLE
Introduce CLI flag for systemimage server urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ The easy way to install Ubuntu Touch on UBports devices. A friendly cross-platfo
 https://devices.ubuntu-touch.io
 
 Options:
-  -V, --version      output the version number
-  -f, --file <file>  Override the official config by loading a local file
-  -v, --verbose      Print debugging information. Multiple -v options increase the verbosity
-  -d, --debug        Enable electron's web debugger to inspect the frontend
-  -h, --help         output usage information
+  -V, --version        output the version number
+  -f, --file <file>    Override the official config by loading a YAML local file
+  -v, --verbose        Print debugging information. Multiple -v options increase the verbosity
+  -d, --debug          Enable electron's web debugger to inspect the frontend (default: false)
+  --systemimage <url>  Set a custom systemimage server url (default:
+                       "https://system-image.ubports.com/")
+  -h, --help           display help for command
 ```
 
 ### Lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^0.26.1",
         "bootstrap": "^5.1.3",
         "cancelable-promise": "^4.3.0",
-        "commander": "^8.3.0",
+        "commander": "^9.0.0",
         "electron-open-link-in-browser": "^1.0.2",
         "electron-store": "^8.0.1",
         "form-data": "^4.0.0",
@@ -3042,11 +3042,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/commondir": {
@@ -12899,9 +12899,9 @@
       }
     },
     "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
     },
     "commondir": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "axios": "^0.26.1",
     "bootstrap": "^5.1.3",
     "cancelable-promise": "^4.3.0",
-    "commander": "^8.3.0",
+    "commander": "^9.0.0",
     "electron-open-link-in-browser": "^1.0.2",
     "electron-store": "^8.0.1",
     "form-data": "^4.0.0",

--- a/src/core/plugins/core/plugin.spec.js
+++ b/src/core/plugins/core/plugin.spec.js
@@ -1,3 +1,4 @@
+process.argv = [null, null, "-vv"];
 const mainEvent = { emit: jest.fn() };
 const log = { error: jest.fn(), debug: jest.fn(), info: jest.fn() };
 beforeEach(() => {

--- a/src/core/plugins/index.spec.js
+++ b/src/core/plugins/index.spec.js
@@ -1,3 +1,4 @@
+process.argv = [null, null, "-vv"];
 const { plugins } = require("../core.js");
 
 const log = {

--- a/src/core/plugins/systemimage/api.js
+++ b/src/core/plugins/systemimage/api.js
@@ -22,7 +22,7 @@ const path = require("path");
 
 /** @module systemimage */
 
-const baseURL = process.env.SYSTEM_IMAGE_SERVER || "https://system-image.ubports.com/";
+const baseURL = require("../../../lib/cli.js").systemimage;
 
 const api = axios.create({ baseURL, timeout: 15000 });
 

--- a/src/core/plugins/systemimage/api.js
+++ b/src/core/plugins/systemimage/api.js
@@ -22,7 +22,7 @@ const path = require("path");
 
 /** @module systemimage */
 
-const baseURL = "https://system-image.ubports.com/";
+const baseURL = process.env.SYSTEM_IMAGE_SERVER || "https://system-image.ubports.com/";
 
 const api = axios.create({ baseURL, timeout: 15000 });
 

--- a/src/core/plugins/systemimage/plugin.spec.js
+++ b/src/core/plugins/systemimage/plugin.spec.js
@@ -1,3 +1,4 @@
+process.argv = [null, null, "-vv"];
 const api = require("./api.js");
 jest.mock("./api.js");
 api.getImages.mockResolvedValue({

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -48,6 +48,11 @@ cli
     "Enable electron's web debugger to inspect the frontend",
     false
   )
+  .option(
+    "--systemimage <url>",
+    "Set a custom systemimage server url",
+    "https://system-image.ubports.com/"
+  )
   .parse(process.argv);
 
 log.setLevel(cli.opts().verbose || 0);


### PR DESCRIPTION
supercedes #2101.

Use `npm start -- --systemimage "https://wherever.xyz"` for custom settings.