### PR TITLE
Add fastboot:assert_var and adb:assert_prop actions for #2505

### DIFF
--- a/src/core/plugins/adb/plugin.js
+++ b/src/core/plugins/adb/plugin.js
@@ -221,6 +221,24 @@ class AdbPlugin extends Plugin {
       })
       .then(() => null); // ensure null is returned
   }
+
+  /**
+   * adb:assert_prop action
+   * @returns {Promise}
+   */
+  action__assert_prop({ prop, value: expectedValue }) {
+    return Promise.resolve()
+      .then(() => {
+        this.event.emit("user:write:under", `Asserting ${prop} property`);
+      })
+      .then(() => this.adb.getprop(prop))
+      .then(actualValue => {
+        if (actualValue !== expectedValue)
+          throw new Error(
+            `Assertion error: property ${prop} to be ${expectedValue} but got ${actualValue}`
+          );
+      });
+  }
 }
 
 module.exports = AdbPlugin;

--- a/src/core/plugins/adb/plugin.js
+++ b/src/core/plugins/adb/plugin.js
@@ -226,16 +226,24 @@ class AdbPlugin extends Plugin {
    * adb:assert_prop action
    * @returns {Promise}
    */
-  action__assert_prop({ prop, value: expectedValue }) {
+  action__assert_prop({ prop, value: expectedValue, regex }) {
     return Promise.resolve()
       .then(() => {
         this.event.emit("user:write:under", `Asserting ${prop} property`);
       })
       .then(() => this.adb.getprop(prop))
       .then(actualValue => {
-        if (actualValue !== expectedValue)
+        if (
+          !(regex
+            ? actualValue.match(new RegExp(regex.pattern, regex.flags))
+            : actualValue === expectedValue)
+        )
           throw new Error(
-            `Assertion error: property ${prop} to be ${expectedValue} but got ${actualValue}`
+            `Assertion error: expected property ${prop} to ${
+              regex
+                ? `match /${regex.pattern}/${regex.flags || ""}`
+                : `be ${expectedValue}`
+            } but got ${actualValue}`
           );
       });
   }

--- a/src/core/plugins/adb/plugin.spec.js
+++ b/src/core/plugins/adb/plugin.spec.js
@@ -171,42 +171,70 @@ describe("adb plugin", () => {
   });
 
   describe("action__assert_prop()", () => {
-    it("should assert prop", () => {
-      jest.spyOn(adbPlugin.adb, "getprop").mockResolvedValue("asdf");
-      return adbPlugin
-        .action__assert_prop({
+    [
+      {
+        comment: "value",
+        arg: {
           prop: "somevar",
           value: "asdf"
-        })
-        .then(r => {
+        }
+      },
+      {
+        comment: "regex w/ flags",
+        arg: {
+          prop: "somevar",
+          regex: {
+            pattern: "a[s,d]*f",
+            flags: "i"
+          }
+        }
+      },
+      {
+        comment: "regex w/o flags",
+        arg: {
+          prop: "somevar",
+          regex: {
+            pattern: "a[s,d]*f"
+          }
+        }
+      },
+      {
+        comment: "string in regex",
+        arg: {
+          prop: "somevar",
+          regex: {
+            pattern: "asdf"
+          }
+        }
+      }
+    ].forEach(({ comment, arg }) => {
+      it(`should assert and pass prop from ${comment}`, () => {
+        jest.spyOn(adbPlugin.adb, "getprop").mockResolvedValue("asdf");
+        return adbPlugin.action__assert_prop(arg).then(r => {
           expect(r).not.toBeDefined();
-          expect(adbPlugin.adb.getprop).toHaveBeenCalledWith("somevar");
+          expect(adbPlugin.adb.getprop).toHaveBeenCalledWith(arg.prop);
           expect(mainEvent.emit).toHaveBeenCalledWith(
             "user:write:under",
-            "Asserting somevar property"
+            expect.stringMatching(/Asserting .* property/)
           );
           adbPlugin.adb.getprop.mockRestore();
         });
-    });
-    it("should fail assertion", done => {
-      jest.spyOn(adbPlugin.adb, "getprop").mockResolvedValue("wasd");
-      adbPlugin
-        .action__assert_prop({
-          prop: "somevar",
-          value: "asdf"
-        })
-        .catch(e => {
-          expect(e.message).toEqual(
-            "Assertion error: property somevar to be asdf but got wasd"
+      });
+      it(`should assert and fail prop from ${comment}`, done => {
+        jest.spyOn(adbPlugin.adb, "getprop").mockResolvedValue("wasd");
+        adbPlugin.action__assert_prop(arg).catch(e => {
+          expect(e.message).toMatch(
+            /Assertion error: expected property .* to (be|match) .* but got wasd/
           );
-          expect(adbPlugin.adb.getprop).toHaveBeenCalledWith("somevar");
+          expect(adbPlugin.adb.getprop).toHaveBeenCalledWith(arg.prop);
           expect(mainEvent.emit).toHaveBeenCalledWith(
             "user:write:under",
-            "Asserting somevar property"
+            expect.stringMatching(/Asserting .* property/)
           );
           adbPlugin.adb.getprop.mockRestore();
           done();
         });
+      });
     });
   });
 });

--- a/src/core/plugins/adb/plugin.spec.js
+++ b/src/core/plugins/adb/plugin.spec.js
@@ -169,4 +169,44 @@ describe("adb plugin", () => {
       });
     });
   });
+
+  describe("action__assert_prop()", () => {
+    it("should assert prop", () => {
+      jest.spyOn(adbPlugin.adb, "getprop").mockResolvedValue("asdf");
+      return adbPlugin
+        .action__assert_prop({
+          prop: "somevar",
+          value: "asdf"
+        })
+        .then(r => {
+          expect(r).not.toBeDefined();
+          expect(adbPlugin.adb.getprop).toHaveBeenCalledWith("somevar");
+          expect(mainEvent.emit).toHaveBeenCalledWith(
+            "user:write:under",
+            "Asserting somevar property"
+          );
+          adbPlugin.adb.getprop.mockRestore();
+        });
+    });
+    it("should fail assertion", done => {
+      jest.spyOn(adbPlugin.adb, "getprop").mockResolvedValue("wasd");
+      adbPlugin
+        .action__assert_prop({
+          prop: "somevar",
+          value: "asdf"
+        })
+        .catch(e => {
+          expect(e.message).toEqual(
+            "Assertion error: property somevar to be asdf but got wasd"
+          );
+          expect(adbPlugin.adb.getprop).toHaveBeenCalledWith("somevar");
+          expect(mainEvent.emit).toHaveBeenCalledWith(
+            "user:write:under",
+            "Asserting somevar property"
+          );
+          adbPlugin.adb.getprop.mockRestore();
+          done();
+        });
+    });
+  });
 });

--- a/src/core/plugins/fastboot/plugin.js
+++ b/src/core/plugins/fastboot/plugin.js
@@ -318,6 +318,27 @@ class FastbootPlugin extends Plugin {
       .then(() => this.fastboot.wait())
       .then(() => null); // ensure null is returned
   }
+
+  /**
+   * fastboot:wait action
+   * @returns {Promise}
+   */
+  action__assert_var({ variable, value: expectedValue }) {
+    return Promise.resolve()
+      .then(() => {
+        this.event.emit(
+          "user:write:under",
+          `Asserting ${variable} bootloader variable`
+        );
+      })
+      .then(() => this.fastboot.getvar(variable))
+      .then(actualValue => {
+        if (actualValue !== expectedValue)
+          throw new Error(
+            `Assertion error: expected bootloader variable ${variable} to be ${expectedValue} but got ${actualValue}`
+          );
+      });
+  }
 }
 
 module.exports = FastbootPlugin;

--- a/src/core/plugins/fastboot/plugin.js
+++ b/src/core/plugins/fastboot/plugin.js
@@ -320,10 +320,10 @@ class FastbootPlugin extends Plugin {
   }
 
   /**
-   * fastboot:wait action
+   * fastboot:assert_var action
    * @returns {Promise}
    */
-  action__assert_var({ variable, value: expectedValue }) {
+  action__assert_var({ variable, value: expectedValue, regex }) {
     return Promise.resolve()
       .then(() => {
         this.event.emit(
@@ -333,9 +333,17 @@ class FastbootPlugin extends Plugin {
       })
       .then(() => this.fastboot.getvar(variable))
       .then(actualValue => {
-        if (actualValue !== expectedValue)
+        if (
+          !(regex
+            ? actualValue.match(new RegExp(regex.pattern, regex.flags))
+            : actualValue === expectedValue)
+        )
           throw new Error(
-            `Assertion error: expected bootloader variable ${variable} to be ${expectedValue} but got ${actualValue}`
+            `Assertion error: expected bootloader variable ${variable} to ${
+              regex
+                ? `match /${regex.pattern}/${regex.flags || ""}`
+                : `be ${expectedValue}`
+            } but got ${actualValue}`
           );
       });
   }

--- a/src/core/plugins/fastboot/plugin.spec.js
+++ b/src/core/plugins/fastboot/plugin.spec.js
@@ -136,4 +136,47 @@ describe("fastboot plugin", () => {
         });
     });
   });
+  describe("assert_var()", () => {
+    it("should assert var", () => {
+      jest.spyOn(fastbootPlugin.fastboot, "getvar").mockResolvedValue("asdf");
+      return fastbootPlugin
+        .action__assert_var({
+          variable: "somevar",
+          value: "asdf"
+        })
+        .then(r => {
+          expect(r).not.toBeDefined();
+          expect(fastbootPlugin.fastboot.getvar).toHaveBeenCalledWith(
+            "somevar"
+          );
+          expect(mainEvent.emit).toHaveBeenCalledWith(
+            "user:write:under",
+            "Asserting somevar bootloader variable"
+          );
+          fastbootPlugin.fastboot.getvar.mockRestore();
+        });
+    });
+    it("should fail assertion", done => {
+      jest.spyOn(fastbootPlugin.fastboot, "getvar").mockResolvedValue("wasd");
+      fastbootPlugin
+        .action__assert_var({
+          variable: "somevar",
+          value: "asdf"
+        })
+        .catch(e => {
+          expect(e.message).toEqual(
+            "Assertion error: expected bootloader variable somevar to be asdf but got wasd"
+          );
+          expect(fastbootPlugin.fastboot.getvar).toHaveBeenCalledWith(
+            "somevar"
+          );
+          expect(mainEvent.emit).toHaveBeenCalledWith(
+            "user:write:under",
+            "Asserting somevar bootloader variable"
+          );
+          fastbootPlugin.fastboot.getvar.mockRestore();
+          done();
+        });
+    });
+  });
 });

--- a/src/core/plugins/systemimage/plugin.js
+++ b/src/core/plugins/systemimage/plugin.js
@@ -30,7 +30,7 @@ class SystemimagePlugin extends Plugin {
    * systemimage:install action
    * @returns {Promise<Array<Object>>}
    */
-  action__install() {
+  action__install({ verify_recovery } = {}) {
     return api
       .getImages(
         this.props.settings.channel,
@@ -56,6 +56,16 @@ class SystemimagePlugin extends Plugin {
             {
               "adb:wait": null
             },
+            ...(verify_recovery
+              ? [
+                  {
+                    "adb:assert_prop": {
+                      prop: "ro.ubuntu.recovery",
+                      value: "true"
+                    }
+                  }
+                ]
+              : []),
             {
               "adb:preparesystemimage": null
             },

--- a/src/core/plugins/systemimage/plugin.spec.js
+++ b/src/core/plugins/systemimage/plugin.spec.js
@@ -19,8 +19,8 @@ beforeEach(() => jest.clearAllMocks());
 
 describe("systemimage plugin", () => {
   describe("actions", () => {
-    describe("download", () => {
-      it("should create download steps", () =>
+    describe("install", () => {
+      it("should create install actions", () =>
         systemimage.action__install().then(r => {
           expect(r).toHaveLength(1);
           expect(r[0].actions).toHaveLength(5);
@@ -47,6 +47,14 @@ describe("systemimage plugin", () => {
               files: ["f", "ubuntu_command"],
               group: "Ubuntu Touch"
             }
+          });
+        }));
+      it("should verify recovery", () =>
+        systemimage.action__install({ verify_recovery: true }).then(r => {
+          expect(r).toHaveLength(1);
+          expect(r[0].actions).toHaveLength(6);
+          expect(r[0].actions).toContainEqual({
+            "adb:assert_prop": { prop: "ro.ubuntu.recovery", value: "true" }
           });
         }));
     });


### PR DESCRIPTION
Resolves #2505. Specified in https://github.com/ubports/installer-configs/pull/178.

Example:

```yml
        - adb:assert_prop:
            prop: "ro.ubuntu.recovery"
            value: "true"
        - fastboot:assert_var:
            variable: "ro.ubuntu.recovery"
            value: "true"
        - adb:assert_prop:
            prop: "ro.ubuntu.recovery"
            regex:
              pattern: "true"
              flags: "i"
        - fastboot:assert_var:
            variable: "ro.ubuntu.recovery"
            regex:
              pattern: "true"
              flags: "i"
        - systemimage:install:
              verify_recovery: true
```