### PR TITLE
Fix #2536: Cannot destructure property 'verify_recovery'

### DIFF
--- a/src/core/plugins/systemimage/plugin.js
+++ b/src/core/plugins/systemimage/plugin.js
@@ -30,7 +30,7 @@ class SystemimagePlugin extends Plugin {
    * systemimage:install action
    * @returns {Promise<Array<Object>>}
    */
-  action__install({ verify_recovery } = {}) {
+  action__install(arg) {
     return api
       .getImages(
         this.props.settings.channel,
@@ -56,7 +56,7 @@ class SystemimagePlugin extends Plugin {
             {
               "adb:wait": null
             },
-            ...(verify_recovery
+            ...(arg?.verify_recovery
               ? [
                   {
                     "adb:assert_prop": {

--- a/src/core/plugins/systemimage/plugin.spec.js
+++ b/src/core/plugins/systemimage/plugin.spec.js
@@ -21,7 +21,7 @@ describe("systemimage plugin", () => {
   describe("actions", () => {
     describe("install", () => {
       it("should create install actions", () =>
-        systemimage.action__install().then(r => {
+        systemimage.action__install(null).then(r => {
           expect(r).toHaveLength(1);
           expect(r[0].actions).toHaveLength(5);
           expect(r[0].actions).toContainEqual({


### PR DESCRIPTION
worked if nothing was passed, threw an error if null was passed. well. at least it was caught within two hours by [opencuts](https://ubports.open-cuts.org/run/623d2333bfb7110008fb491f) :)