### PR TITLE
Fix `adb:update` action and allow `adb:shell` action to take an array

### DIFF
--- a/src/core/plugins/adb/plugin.js
+++ b/src/core/plugins/adb/plugin.js
@@ -134,8 +134,11 @@ class AdbPlugin extends Plugin {
    * adb:shell action
    * @returns {Promise}
    */
-  action__shell({ args }) {
-    return this.adb.shell(...args).then(() => null); // ensure null is returned
+  action__shell(args) {
+    // TODO 0.10.0: deprecate option to call with an object
+    return this.adb
+      .shell(...(Array.isArray(args) ? args : args.args))
+      .then(() => null); // ensure null is returned
   }
 
   /**

--- a/src/core/plugins/adb/plugin.spec.js
+++ b/src/core/plugins/adb/plugin.spec.js
@@ -101,11 +101,14 @@ describe("adb plugin", () => {
   });
 
   describe("action__shell()", () => {
-    it("should run shell command", () => {
-      jest.spyOn(adbPlugin.adb, "shell").mockResolvedValueOnce();
-      return adbPlugin
-        .action__shell({ args: ["echo", "hello", "world"] })
-        .then(r => {
+    const args = ["echo", "hello", "world"];
+    [
+      { comment: "array", args },
+      { comment: "object", args: { args } }
+    ].forEach(({ comment, args }) =>
+      it(`should run shell command when called with ${comment}`, () => {
+        jest.spyOn(adbPlugin.adb, "shell").mockResolvedValueOnce();
+        return adbPlugin.action__shell(args).then(r => {
           expect(r).toEqual(null);
           expect(adbPlugin.adb.shell).toHaveBeenCalledTimes(1);
           expect(adbPlugin.adb.shell).toHaveBeenCalledWith(
@@ -115,7 +118,8 @@ describe("adb plugin", () => {
           );
           adbPlugin.adb.shell.mockRestore();
         });
-    });
+      })
+    );
   });
 
   describe("action__reboot()", () => {

--- a/src/core/plugins/fastboot/plugin.js
+++ b/src/core/plugins/fastboot/plugin.js
@@ -284,7 +284,7 @@ class FastbootPlugin extends Plugin {
    * fastboot:update action
    * @returns {Promise}
    */
-  action__update({ group, file, partition }) {
+  action__update({ group, file }) {
     return Promise.resolve().then(() => {
       this.event.emit("user:write:working", "particles");
       this.event.emit("user:write:status", "Updating system", true);
@@ -293,13 +293,8 @@ class FastbootPlugin extends Plugin {
         "Applying fastboot update zip. This may take a while..."
       );
       return this.fastboot.update(
-        path.join(
-          this.cachePath,
-          this.props.config.codename,
-          step.group,
-          step.file
-        ),
-        this.props.settings.wipe
+        path.join(this.cachePath, this.props.config.codename, group, file),
+        this?.props?.settings?.wipe
       );
     });
   }

--- a/src/core/plugins/fastboot/plugin.spec.js
+++ b/src/core/plugins/fastboot/plugin.spec.js
@@ -37,6 +37,16 @@ describe("fastboot plugin", () => {
       });
     });
   });
+  describe("update()", () => {
+    it("should update", () => {
+      jest.spyOn(fastbootPlugin.fastboot, "update").mockResolvedValue();
+      return fastbootPlugin.action__update({group: "group", file: "image"}).then(() => {
+        expect(fastbootPlugin.fastboot.update).toHaveBeenCalledTimes(1);
+        expect(fastbootPlugin.fastboot.update).toHaveBeenCalledWith(expect.stringMatching(/.*group.image/), undefined);
+        fastbootPlugin.fastboot.update.mockRestore();
+      });
+    });
+  });
   describe("oem_unlock()", () => {
     it("should unlock", () => {
       mainEvent.emit.mockImplementation((m, d, a, cb) => cb());


### PR DESCRIPTION
Some shit i found while working on https://github.com/ubports/installer-configs/pull/182.