### PR TITLE
Fix bug in `adb:reconnect`

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -306,7 +306,7 @@ class Core {
    * @returns {Promise}
    */
   run(steps) {
-    if (!(steps && steps.length)) return Promise.resolve();
+    if (!(steps && Array.isArray(steps))) return Promise.resolve();
     return steps
       .map(step => () => this.step(step))
       .reduce((chain, next) => chain.then(next), Promise.resolve())

--- a/src/core/core.spec.js
+++ b/src/core/core.spec.js
@@ -336,6 +336,7 @@ describe("Core module", () => {
         core.step.mockRestore();
       });
     });
+    it("should resolve if called with non-array", () => core.run(true));
     it("should fail silently", () => {
       jest.spyOn(core, "step").mockRejectedValue();
       return core.run(steps).then(() => {

--- a/src/core/plugins/adb/plugin.js
+++ b/src/core/plugins/adb/plugin.js
@@ -168,6 +168,7 @@ class AdbPlugin extends Plugin {
       .then(() => this.adb.reconnect())
       .catch(() => this.adb.reconnect())
       .catch(() => this.adb.reconnect())
+      .then(() => null) // ensure null is resolved
       .catch(
         () =>
           new Promise((resolve, reject) =>

--- a/src/core/plugins/adb/plugin.spec.js
+++ b/src/core/plugins/adb/plugin.spec.js
@@ -137,7 +137,7 @@ describe("adb plugin", () => {
       jest.spyOn(adbPlugin.event, "emit").mockReturnValue();
       jest.spyOn(adbPlugin.adb, "reconnect").mockResolvedValueOnce();
       return adbPlugin.action__reconnect().then(r => {
-        expect(r).toEqual(undefined);
+        expect(r).toEqual(null);
         expect(adbPlugin.event.emit).toHaveBeenCalledTimes(3);
         expect(adbPlugin.adb.reconnect).toHaveBeenCalledTimes(1);
         adbPlugin.adb.reconnect.mockRestore();


### PR DESCRIPTION
Fix issue where `adb:reconnect` returned non-null.

Make sure `core.run()` does not try to map something that is not steps.

Seen in https://ubports.open-cuts.org/run/623e5981bfb7110008fb5d98:

```
verbose: running step {"actions":[{"adb:reconnect":{}}]}
verbose: running adb action reconnect
command: exec: {"cmd":["adb","-P",5037,"reconnect"],"stdout":"reconnecting 86a0ca6b0408 [recovery]","stderr":"adb server version (40) doesn't match this client (41); killing...\r\n* daemon started successfully"}
command: exec: {"cmd":["adb","-P",5037,"wait-for-any-any"],"stderr":"adb server version (40) doesn't match this client (41); killing...\r\n* daemon started successfully"}
command: exec: {"cmd":["adb","-P",5037,"get-state"],"stdout":"recovery"}
debug: attempting to handle TypeError: steps.map is not a function
error: Error: unknown: TypeError: steps.map is not a function
stack trace: TypeError: steps.map is not a function
    at Core.run (C:\Users\romolo18\AppData\Local\Temp\26sAVjW7NLXFaztwov15MoSmUkC\resources\app.asar\src\core\core.js:311:8)
    at C:\Users\romolo18\AppData\Local\Temp\26sAVjW7NLXFaztwov15MoSmUkC\resources\app.asar\src\core\core.js:356:42
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```