### PR TITLE
main: do not lower priority of rendering when in background

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,12 @@ const reporter = require("./lib/reporter.js");
 const menuManager = require("./lib/menuManager.js");
 const core = require("./core/core.js");
 
+// Do not lower priority of rendering when in background
+// - See: https://www.electronjs.org/de/docs/latest/api/command-line-switches#--disable-renderer-backgrounding
+if (typeof app.commandLine !== "undefined") {
+  app.commandLine.appendSwitch("disable-renderer-backgrounding");
+}
+
 // Enable live reload for Electron
 if (process.env.ROLLUP_WATCH) {
   require("electron-reload")(path.resolve("./public"), {


### PR DESCRIPTION
This prevents rendering getting slow when switching to other
applications while installing, which results in the installer
interacting with the device while GUI is trying to catch up
with the installation process.