### PR TITLE
setup-dev.sh: Add Void Linux support

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -27,6 +27,10 @@ case "${distro}" in
         fi
         packages="npm nodejs"
         ;;
+    "VoidLinux")
+        packageCommand="xbps-install"
+        packages="nodejs"
+        ;;
     "*")
         packages="npm nodejs-legacy"
         echo "Distro could not be identified. Please add yours to the script."


### PR DESCRIPTION
Add install command for `nodejs` (`npm` included) on [Void Linux](https://voidlinux.org).