### PR TITLE
Fix restart button when Done

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -108,6 +108,16 @@
     yumi.setPosition("center");
   });
 
+  ipcRenderer.on("user:restart", () => {
+    push("/");
+    footerData.set({
+      topText: "Restarting",
+      underText: `UBports Installer is restarting`,
+      waitingDots: true
+    });
+    yumi.setPosition("foot");
+  });
+
   //Error handling
   // Catch all unhandled errors in rendering process
   window.onerror = (err, url, line) => {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -72,12 +72,13 @@ class Core {
   /**
    * prepare the installer: start adb server and get device selects or read config
    * @param {String} [file] config file
+   * @param {Boolean} [restart] set to true to skip adb start
    * @returns {Promise}
    */
-  prepare(file) {
+  prepare(file, restart = false) {
     return Promise.all([
       this.readConfigFile(file),
-      this.plugins.init().catch(e => errors.toUser(e, "initializing plugins"))
+      !restart && this.plugins.init().catch(e => errors.toUser(e, "initializing plugins"))
     ]).then(() => {
       if (this.props.config) {
         this.selectOs();

--- a/src/core/core.spec.js
+++ b/src/core/core.spec.js
@@ -39,15 +39,29 @@ beforeEach(() => jest.restoreAllMocks());
 
 describe("Core module", () => {
   describe("prepare()", () => {
-    it("should prepare and read config", () => {
+    it("should prepare and read config at start", () => {
       jest.spyOn(core, "readConfigFile").mockResolvedValueOnce();
       jest.spyOn(core.plugins, "init").mockResolvedValueOnce();
       jest.spyOn(core, "selectOs").mockResolvedValueOnce();
-      return core.prepare("a").then(() => {
+      return core.prepare("a", false).then(() => {
         expect(core.readConfigFile).toHaveBeenCalledWith("a");
         expect(core.readConfigFile).toHaveBeenCalledTimes(1);
         core.readConfigFile.mockRestore();
         expect(core.plugins.init).toHaveBeenCalledTimes(1);
+        core.plugins.init.mockRestore();
+        expect(core.selectOs).toHaveBeenCalledTimes(1);
+        core.selectOs.mockRestore();
+      });
+    });
+    it("should prepare and read config at restart", () => {
+      jest.spyOn(core, "readConfigFile").mockResolvedValueOnce();
+      jest.spyOn(core.plugins, "init").mockResolvedValueOnce();
+      jest.spyOn(core, "selectOs").mockResolvedValueOnce();
+      return core.prepare("a", true).then(() => {
+        expect(core.readConfigFile).toHaveBeenCalledWith("a");
+        expect(core.readConfigFile).toHaveBeenCalledTimes(1);
+        core.readConfigFile.mockRestore();
+        expect(core.plugins.init).toHaveBeenCalledTimes(0);
         core.plugins.init.mockRestore();
         expect(core.selectOs).toHaveBeenCalledTimes(1);
         core.selectOs.mockRestore();

--- a/src/lib/__mocks__/mainEvent.js
+++ b/src/lib/__mocks__/mainEvent.js
@@ -1,0 +1,12 @@
+let handlers = new Map();
+
+const mainEvent = {
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  emit(event) {
+    handlers.get(event)();
+  }
+};
+
+module.exports = mainEvent;

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,7 @@ const mainEvent = require("./lib/mainEvent.js");
 const reporter = require("./lib/reporter.js");
 const menuManager = require("./lib/menuManager.js");
 const core = require("./core/core.js");
+const window = require("./lib/window.js");
 
 // Enable live reload for Electron
 if (process.env.ROLLUP_WATCH) {
@@ -48,8 +49,9 @@ ipcMain.on("reportResult", async (event, result, error) => {
 // FIXME move after a better way to access mainWindow has been found
 mainEvent.on("restart", () => {
   log.info("UBports Installer restarting...");
-  core.kill();
-  mainWindow.reload();
+  window.send("user:restart")
+  core.reset();
+  core.prepare(cli.file, true)
 });
 
 async function createWindow() {

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -3,7 +3,27 @@ process.argv = [null, null, "-vv"];
 const { ipcMain } = require("electron");
 jest.mock("electron");
 process.argv = [];
+const mainEvent = require("./lib/mainEvent.js");
+jest.mock("./lib/mainEvent.js");
+const { main } = require("./main.js");
+const window = require("./lib/window.js");
+jest.mock("./lib/window.js");
+const core = require("./core/core.js");
+jest.mock("./core/core.js");
 
 it("should be a singleton", () => {
   expect(require("./main.js")).toBeDefined();
+});
+
+describe("main", () => {
+  describe("restart", () => {
+    it("should restart the app", () => {
+      mainEvent.emit("restart");
+      expect(window.send).toHaveBeenCalledWith("user:restart");
+      expect(window.send).toHaveBeenCalledTimes(1);
+      expect(core.reset).toHaveBeenCalledTimes(1);
+      expect(core.prepare).toHaveBeenCalledTimes(1);
+      expect(core.prepare).toHaveBeenCalledWith(undefined, true);
+    });
+  });
 });


### PR DESCRIPTION
When the flashing process completes the user is asked if they want to
flash another device. Currently the button seems to do nothing; these
changes return the app back to the start screen to allow the user to
attempt another flashing process.