### PR TITLE
Delay activation of manual device select button

### DIFF
--- a/src/ui/views/WaitForDevice.svelte
+++ b/src/ui/views/WaitForDevice.svelte
@@ -8,6 +8,7 @@
     showSelectDeviceModal
   } from "../../stores.mjs";
 
+  let initialized = false;
   ipcRenderer.on("device:wait:device-selects-ready", (event, deviceSelects) => {
     footerData.set({
       topText: "Waiting for device",
@@ -15,6 +16,7 @@
       waitingDots: true
     });
     deviceSelectOptions.set(deviceSelects);
+    initialized = true;
   });
 </script>
 
@@ -49,10 +51,15 @@
     </p>
     <button
       id="btn-modal-select-device"
+      disabled={!initialized}
       class="btn btn-outline-dark"
       on:click={() => showSelectDeviceModal.set(true)}
     >
-      Select device manually
+      {#if initialized}
+         Select device manually
+      {:else}
+         Loading device list...
+      {/if}
     </button>
   </div>
 </div>


### PR DESCRIPTION
When the app first starts up there can be a slight delay before the
configuration files have been downloaded and adb starts up.

During this time, if the "Select device manually" button is pressed by
the user, the device selection combobox will be empty, which can be
confusing for the user.

This change disables the button until initialisation is complete,
displaying a "Loading device list..." message in the meantime.