### PR TITLE
Disable manual download buttons during checksum test

### DIFF
--- a/src/core/plugins/core/plugin.js
+++ b/src/core/plugins/core/plugin.js
@@ -22,6 +22,7 @@ const fs = require("fs-extra");
 const path = require("path");
 const { download, checkFile } = require("progressive-downloader");
 const { unpack } = require("../../helpers/asarLibs.js");
+const window = require("../../../lib/window.js");
 
 /**
  * core plugin
@@ -276,6 +277,7 @@ class CorePlugin extends Plugin {
               )
             )
             .then(ok => {
+              window.send("user:manual_download:check", ok);
               if (ok) {
                 return ok;
               } else {

--- a/src/ui/views/ManualDownload.svelte
+++ b/src/ui/views/ManualDownload.svelte
@@ -1,4 +1,5 @@
 <script>
+  const { ipcRenderer } = require("electron");
   import {
     manualDownloadFileData,
     manualDownloadGroup,
@@ -6,8 +7,14 @@
   } from "../../stores.mjs";
 
   let downloadedFile;
+  let checkingFile = false;
 
   function handleManualDownloadButton() {
+    checkingFile = true;
+    ipcRenderer.once("user:manual_download:check", (event, ok) => {
+      checkingFile = false;
+    });
+
     $eventObject.sender.send(
       "manual_download:completed",
       downloadedFile[0].path
@@ -40,14 +47,21 @@
     </p>
     <div class="input-group" style="margin-bottom: 1em;">
       <div class="custom-file">
-        <input type="file" bind:files={downloadedFile} />
+        <input type="file" bind:files={downloadedFile}
+          disabled={checkingFile}
+        />
       </div>
     </div>
     <button
       id="manual-download-button"
       class="btn btn-primary"
-      disabled={!downloadedFile}
-      on:click={() => handleManualDownloadButton()}>Continue</button
-    >
+      disabled={!downloadedFile || checkingFile}
+      on:click={() => handleManualDownloadButton()}>
+      {#if checkingFile}
+        Checking file...
+      {:else}
+        Continue
+      {/if}
+    </button>
   </div>
 </div>


### PR DESCRIPTION
After manually downloading a file, a checksum test is performed on the
file. For large files this test can take some time (seconds), and
there's currently no indication in the UI that this is taking place.

This change disables the file selector and "Continue" buttons during the
checksum test, changing the text in the button to "Checking..." instead.
This provides immediate feedback for the user and avoids the confusion
of allowing them to still use the buttons while the check is taking
place.