### PR TITLE
 Keep track of ignored errors, resolves #2533 

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -391,14 +391,7 @@ class Core {
     } else if (error && error.message.includes("killed")) {
       throw error; // Used for exiting the installer
     } else {
-      return new Promise((resolve, reject) =>
-        errors.toUser(
-          error,
-          location,
-          () => resolve(this.step(step)), // try again
-          () => resolve(null) // ignore
-        )
-      );
+      return errors.toUser(error, location, () => this.step(step));
     }
   }
 

--- a/src/core/core.spec.js
+++ b/src/core/core.spec.js
@@ -523,9 +523,7 @@ describe("Core module", () => {
       }
     });
     it("should let the user ignore the error", () => {
-      jest
-        .spyOn(errors, "toUser")
-        .mockImplementation((e, l, again, ignore) => ignore());
+      jest.spyOn(errors, "toUser").mockResolvedValueOnce(null);
       return core
         .handle(new Error("some error"), "a:x", { actions: [{ "a:x": null }] })
         .then(r => expect(r).toEqual(null));

--- a/src/lib/__mocks__/mainEvent.js
+++ b/src/lib/__mocks__/mainEvent.js
@@ -4,8 +4,12 @@ const mainEvent = {
   on(event, handler) {
     handlers.set(event, handler);
   },
-  emit(event) {
-    handlers.get(event)();
+  emit(event, ...args) {
+    if (typeof handlers.get(event) == "function") {
+      handlers.get(event)(...args);
+    } else {
+      throw new Error(`register listener '${event}': 'mainEvent.on(${event})'`);
+    }
   }
 };
 

--- a/src/lib/__mocks__/mainEvent.js
+++ b/src/lib/__mocks__/mainEvent.js
@@ -5,11 +5,9 @@ const mainEvent = {
     handlers.set(event, handler);
   },
   emit(event, ...args) {
-    if (typeof handlers.get(event) == "function") {
-      handlers.get(event)(...args);
-    } else {
+    if (typeof handlers.get(event) != "function")
       throw new Error(`register listener '${event}': 'mainEvent.on(${event})'`);
-    }
+    handlers.get(event)(...args);
   }
 };
 

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -49,25 +49,22 @@ class ErrorHandler {
    * @param {Function} ignore callback
    */
   async toUser(error, errorLocation, restart, ignore) {
-    if (window.getMain()) {
-      return new Promise(resolve => {
-        const message = `Error: ${errorLocation || "Unknown"}: ${error}`;
-        const stack = error.stack ? "\nstack trace: " + error.stack : "";
-        log.error(message + stack);
-        const cont = continuePromise => {
-          this.errors.push(message + stack);
-          resolve(continuePromise ? continuePromise() : null);
-        };
-        mainEvent.emit(
-          "user:error",
-          message,
-          () => cont(restart),
-          () => cont(ignore)
-        );
-      });
-    } else {
-      errorHandler.die(error);
-    }
+    if (!window.getMain()) return errorHandler.die(error);
+    return new Promise(resolve => {
+      const message = `Error: ${errorLocation || "Unknown"}: ${error}`;
+      const stack = error.stack ? "\nstack trace: " + error.stack : "";
+      log.error(message + stack);
+      const cont = continuePromise => {
+        this.errors.push(message + stack);
+        resolve(continuePromise ? continuePromise() : null);
+      };
+      mainEvent.emit(
+        "user:error",
+        message,
+        () => cont(restart),
+        () => cont(ignore)
+      );
+    });
   }
 }
 

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*
- * Copyright (C) 2017-2020 UBports Foundation <info@ubports.com>
+ * Copyright (C) 2017-2022 UBports Foundation <info@ubports.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,8 +24,13 @@ const mainEvent = require("./mainEvent.js");
 
 /**
  * error handling
+ * @property {Array<Error>} errors all escalated errors
  */
 class ErrorHandler {
+  constructor() {
+    this.errors = [];
+  }
+
   /**
    * die. expire. succumb. perish. decease. depart.
    * @param {Error} error error or message
@@ -43,13 +48,23 @@ class ErrorHandler {
    * @param {Function} restart callback
    * @param {Function} ignore callback
    */
-  toUser(error, errorLocation, restart, ignore) {
-    const errorString = `Error: ${errorLocation || "Unknown"}: ${error}`;
-    log.error(
-      errorString + (error.stack ? "\nstack trace: " + error.stack : "")
-    );
+  async toUser(error, errorLocation, restart, ignore) {
     if (window.getMain()) {
-      mainEvent.emit("user:error", errorString, restart, ignore);
+      return new Promise(resolve => {
+        const message = `Error: ${errorLocation || "Unknown"}: ${error}`;
+        const stack = error.stack ? "\nstack trace: " + error.stack : "";
+        log.error(message + stack);
+        const cont = continuePromise => {
+          this.errors.push(message + stack);
+          resolve(continuePromise ? continuePromise() : null);
+        };
+        mainEvent.emit(
+          "user:error",
+          message,
+          () => cont(restart),
+          () => cont(ignore)
+        );
+      });
     } else {
       errorHandler.die(error);
     }

--- a/src/lib/errors.spec.js
+++ b/src/lib/errors.spec.js
@@ -1,7 +1,60 @@
 process.argv = [null, null, "-vv"];
 const { ipcMain } = require("electron");
 jest.mock("electron");
+const window = require("./window.js");
+jest.mock("./window.js");
+const mainEvent = require("./mainEvent.js");
+jest.mock("./mainEvent.js");
+const errors = require("./errors.js");
 
 it("should be a singleton", () => {
   expect(require("./errors.js")).toBe(require("./errors.js"));
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe("toUser()", () => {
+  it("should die if no window", () => {
+    window.getMain.mockReturnValue(false);
+    jest.spyOn(errors, "die").mockReturnValue();
+    return errors.toUser(new Error("some error"), "here").then(() => {
+      expect(errors.die).toHaveBeenCalledTimes(1);
+      expect(errors.die).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+  it("should escalate and restart", () => {
+    window.getMain.mockReturnValue(true);
+    mainEvent.on("user:error", (message, restart, ignore) => {
+      expect(message).toEqual("Error: here: Error: some error");
+      expect(restart).toBeInstanceOf(Function);
+      expect(ignore).toBeInstanceOf(Function);
+      restart();
+    });
+    return errors
+      .toUser(
+        new Error("some error"),
+        "here",
+        () => Promise.resolve("this is expected"),
+        () => Promise.reject("this should not have been called")
+      )
+      .then(r => {
+        expect(r).toEqual("this is expected");
+      });
+  });
+  it("should escalate and ignore", () => {
+    window.getMain.mockReturnValue(true);
+    mainEvent.on("user:error", (message, restart, ignore) => {
+      expect(message).toEqual("Error: Unknown: some error");
+      expect(restart).toBeInstanceOf(Function);
+      expect(ignore).toBeInstanceOf(Function);
+      ignore();
+    });
+    return errors
+      .toUser("some error", null, () =>
+        Promise.reject("this should not have been called")
+      )
+      .then(r => {
+        expect(r).toEqual(null);
+      });
+  });
 });

--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -25,6 +25,7 @@ const log = require("./log.js");
 const { OpenCutsReporter } = require("open-cuts-reporter");
 const settings = require("./settings.js");
 const cli = require("./cli.js");
+const errors = require("./errors.js");
 const core = require("../core/core.js");
 const { prompt } = require("./prompt.js");
 const { paste } = require("./paste.js");
@@ -114,6 +115,13 @@ class Reporter {
         data.comment && `\n${data.comment?.trim()}\n`,
         ...(data.error && data.error !== "Unknown Error"
           ? ["**Error:**", "```", data.error, "```"]
+          : []),
+        ...(errors.errors?.length
+          ? [
+              "\n**Previous Errors:**\n```",
+              errors.errors.join("\n```\n```\n"),
+              "```"
+            ]
           : []),
         "<!-- thank you for reporting! -->\n"
       ]

--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -193,7 +193,10 @@ class Reporter {
           {
             name: "ubports-installer.log",
             content: await logfile
-          }
+          },
+          ...(errors.errors?.length
+            ? [{ name: "ignored errors", content: errors.errors.join("\n\n") }]
+            : [])
         ]
       }
     );
@@ -297,7 +300,8 @@ class Reporter {
       ],
       confirm: "Send",
       extraData: {
-        result: "PASS"
+        // HACK: Set WONKY if errors had been ignored, even if PASS was specified
+        result: errors.errors?.length ? "WONKY" : "PASS"
       }
     };
   }

--- a/src/lib/reporter.spec.js
+++ b/src/lib/reporter.spec.js
@@ -1,6 +1,8 @@
 process.argv = [null, null, "-vv"];
 const log = require("./log.js");
 jest.mock("./log.js");
+const errors = require("./errors.js");
+jest.mock("./errors.js");
 const { paste } = require("./paste.js");
 jest.mock("./paste.js");
 const cli = require("./cli.js");
@@ -87,26 +89,39 @@ describe("getDeviceLinkMarkdown()", () => {
 
 describe("getDebugInfo()", () => {
   it("should resolve debug without error", () => {
+    errors.errors = ["error one"];
     return reporter
       .getDebugInfo({ error: "Everything exploded", comment: "oh no" })
       .then(decodeURIComponent)
-      .then(r =>
-        expect(r).toContain(
-          "\noh no\n\n" + "**Error:**\n```\nEverything exploded\n```"
-        )
+      .then(
+        r =>
+          expect(r).toContain("\noh no\n\n") &&
+          expect(r).toContain("**Error:**\n```\nEverything exploded\n```")
       );
   });
   it("should resolve debug without error on unknown", () => {
+    errors.errors = [];
     return reporter
       .getDebugInfo({ error: "Unknown Error" })
       .then(decodeURIComponent)
-      .then(r => expect(r).not.toContain("**Error:**"));
+      .then(
+        r =>
+          expect(r).not.toContain("**Error:**") &&
+          expect(r).not.toContain("**Previous Errors:**")
+      );
   });
   it("should resolve debug without error on null", () => {
+    errors.errors = ["error one", "error two"];
     return reporter
       .getDebugInfo({})
       .then(decodeURIComponent)
-      .then(r => expect(r).not.toContain("**Error:**"));
+      .then(
+        r =>
+          expect(r).not.toContain("**Error:**") &&
+          expect(r).toContain("**Previous Errors:**") &&
+          expect(r).toContain("error one") &&
+          expect(r).toContain("error two")
+      );
   });
 });
 

--- a/src/lib/reporter.spec.js
+++ b/src/lib/reporter.spec.js
@@ -88,10 +88,12 @@ describe("getDeviceLinkMarkdown()", () => {
 describe("getDebugInfo()", () => {
   it("should resolve debug without error", () => {
     return reporter
-      .getDebugInfo({ error: "Everything exploded" })
+      .getDebugInfo({ error: "Everything exploded", comment: "oh no" })
       .then(decodeURIComponent)
       .then(r =>
-        expect(r).toContain("**Error:**\n```\nEverything exploded\n```")
+        expect(r).toContain(
+          "\noh no\n\n" + "**Error:**\n```\nEverything exploded\n```"
+        )
       );
   });
   it("should resolve debug without error on unknown", () => {
@@ -110,6 +112,7 @@ describe("getDebugInfo()", () => {
 
 describe("prepareErrorReport()", () => {
   it("should return error report object", () => {
+    core.props = {};
     return reporter.prepareErrorReport().then(r => expect(r).toBeDefined);
   });
 });
@@ -123,13 +126,15 @@ describe("prepareSuccessReport()", () => {
 describe("sendBugReport()", () => {
   it("should send bug report", () => {
     log.get.mockResolvedValue("log content");
+    jest.spyOn(reporter, "sendOpenCutsRun").mockRejectedValueOnce();
     return reporter
       .sendBugReport({
         title: "wasd"
       })
       .then(r => {
         expect(r).toEqual(undefined);
-      });
+      })
+      .finally(() => jest.restoreAllMocks());
   });
 });
 

--- a/src/lib/reporter.spec.js
+++ b/src/lib/reporter.spec.js
@@ -156,11 +156,66 @@ describe("sendBugReport()", () => {
 describe("sendOpenCutsRun()", () => {
   it("should send open-cuts run", () => {
     log.get.mockResolvedValue("log content");
+    errors.errors = ["error one", "error two"];
+    const smartRun = jest.fn();
+    OpenCutsReporter.mockImplementation(() => ({
+      smartRun
+    }));
+    return reporter
+      .sendOpenCutsRun(null, {
+        result: "FAIL"
+      })
+      .then(r => {
+        expect(r).toEqual(undefined);
+        expect(smartRun).toHaveBeenCalledTimes(1);
+        expect(smartRun).toHaveBeenCalledWith(
+          "5e9d746c6346e112514cfec7",
+          "5e9d75406346e112514cfeca",
+          expect.any(String),
+          {
+            combination: [
+              { value: undefined, variable: "Environment" },
+              { value: undefined, variable: "Package" }
+            ],
+            comment: undefined,
+            logs: [
+              { content: "log content", name: "ubports-installer.log" },
+              { content: "error one\n\nerror two", name: "ignored errors" }
+            ],
+            result: "FAIL"
+          }
+        );
+      });
+  });
+  it("should send open-cuts run", () => {
+    log.get.mockResolvedValue("log content");
+    errors.errors = [];
+    const smartRun = jest.fn();
+    OpenCutsReporter.mockImplementation(() => ({
+      smartRun
+    }));
     return reporter
       .sendOpenCutsRun(null, {
         result: "PASS"
       })
-      .then(r => expect(r).toEqual(undefined));
+      .then(r => {
+        expect(r).toEqual(undefined);
+        expect(smartRun).toHaveBeenCalledTimes(1);
+        expect(smartRun).toHaveBeenCalledWith(
+          "5e9d746c6346e112514cfec7",
+          "5e9d75406346e112514cfeca",
+          expect.any(String),
+          {
+            combination: [
+              { value: undefined, variable: "Environment" },
+              { value: undefined, variable: "Package" }
+            ],
+            comment: undefined,
+            logs: [{ content: "log content", name: "ubports-installer.log" }],
+            result: "PASS"
+          }
+        );
+      });
   });
 });
 

--- a/src/main.spec.js
+++ b/src/main.spec.js
@@ -4,7 +4,6 @@ const { ipcMain } = require("electron");
 jest.mock("electron");
 process.argv = [];
 const mainEvent = require("./lib/mainEvent.js");
-jest.mock("./lib/mainEvent.js");
 const { main } = require("./main.js");
 const window = require("./lib/window.js");
 jest.mock("./lib/window.js");


### PR DESCRIPTION
Users are often reluctant to report the first error they run into and chose to ignore it. If something does not work, they report it later and the error gets buried in the log. We should keep track of these and include them in the bug reports.

If any errors have been ignored, the PASS reporting option should be disabled. Even if everything worked, the correct status to report in this case is WONKY, as a workaround was required.