### PR TITLE
Display provided link from user action

### DIFF
--- a/src/ui/views/UserAction.svelte
+++ b/src/ui/views/UserAction.svelte
@@ -19,6 +19,11 @@
     <p>
       {$actionData.description}
     </p>
+    {#if $actionData.link}
+      <p>
+        <a href={$actionData.link}>More...</a>
+      </p>
+    {/if}
     {#if $actionData.button}
       <button
         class="btn btn-primary"


### PR DESCRIPTION
Currently the user action link only gets displayed in the popup view but
not in the full-page view that you get from a fallback action. Fix that.


![installer](https://user-images.githubusercontent.com/3768500/184079957-e4e9d131-e3c7-42a2-a611-e0136cdce8b2.png)

Before the "More..." button just wasn't present.