### PR TITLE
release: 0.9.7-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "7zip-min": "^1.4.3",
         "axios": "^0.27.2",
-        "bootstrap": "^5.2.0",
+        "bootstrap": "^5.2.1",
         "cancelable-promise": "^4.3.0",
         "commander": "^9.4.0",
         "electron-open-link-in-browser": "^1.0.2",
@@ -21,14 +21,14 @@
         "graphql": "^16.6.0",
         "open-cuts-reporter": "^1.0.2",
         "progressive-downloader": "^1.0.7",
-        "promise-android-tools": "^4.0.11",
+        "promise-android-tools": "^4.0.13",
         "ps-tree": "^1.2.0",
         "semver": "^7.3.7",
         "sudo-prompt": "^9.2.1",
         "svelte-markdown": "^0.2.3",
         "sveltestrap": "^5.9.0",
         "systeminformation": "^5.12.6",
-        "winston": "^3.8.1",
+        "winston": "^3.8.2",
         "yaml": "^2.1.1"
       },
       "bin": {
@@ -1390,9 +1390,9 @@
       "dev": true
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.35",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.35.tgz",
-      "integrity": "sha512-iN6ehuDndiTiDz2F+Orv/+oHJR+PrGv+38oghCddpsW4YEZl5qyLsWxSwYUWrKEOfjpGtXDFW6scJtjpzSLeSw==",
+      "version": "0.24.38",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.38.tgz",
+      "integrity": "sha512-IbYB6vdhLFmzGEyXXEdFAJKyq7S4/RsivkgxNzs/LzwYuUJHmeNQ0cHkjG/Yqm6VgUzzZDLMZAf0XgeeaZAocA==",
       "dev": true
     },
     "node_modules/@sindresorhus/is": {
@@ -2453,9 +2453,9 @@
       "optional": true
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.1.tgz",
+      "integrity": "sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==",
       "funding": [
         {
           "type": "github",
@@ -2467,7 +2467,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/boxen": {
@@ -4205,9 +4205,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.242.tgz",
-      "integrity": "sha512-nPdgMWtjjWGCtreW/2adkrB2jyHjClo9PtVhR6rW+oxa4E4Wom642Tn+5LslHP3XPL5MCpkn5/UEY60EXylNeQ==",
+      "version": "1.4.243",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.243.tgz",
+      "integrity": "sha512-BgLD2gBX43OSXwlT01oYRRD5NIB4n3okTRxkzEAC6G0SZG4TTlyrWMjbOo0fajCwqwpRtMHXQNMjtRN6qpNtfw==",
       "dev": true
     },
     "node_modules/electron/node_modules/@types/node": {
@@ -8016,13 +8016,13 @@
       }
     },
     "node_modules/promise-android-tools": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.11.tgz",
-      "integrity": "sha512-pW0IiMjqvjXxJvP2so08AO6kwPIPFscxNdMtC6VfwerCkmXdgPuBaG4nHYJeKkDc6/eJaTTxG1oZ6gqEh93lWA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.13.tgz",
+      "integrity": "sha512-fkCzf8jVE+U1J7O3o9cM251TNQUtnXk/MrUb4FG6yYZ6QZuODxDPvONSsFyu/NW2tZCHKivVHFCmB7IEwj5QYg==",
       "dependencies": {
-        "android-tools-bin": "^1.0.6",
+        "android-tools-bin": "^1.0.7",
         "cancelable-promise": "^3.2.3",
-        "fs-extra": "^10.0.1"
+        "fs-extra": "^10.1.0"
       }
     },
     "node_modules/promise-android-tools/node_modules/cancelable-promise": {
@@ -10226,10 +10226,11 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.1.tgz",
-      "integrity": "sha512-r+6YAiCR4uI3N8eQNOg8k3P3PqwAm20cLKlzVD9E66Ch39+LZC+VH1UKf9JemQj2B3QoUHfKD7Poewn0Pr3Y1w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
+      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
       "dependencies": {
+        "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
@@ -11465,9 +11466,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.24.35",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.35.tgz",
-      "integrity": "sha512-iN6ehuDndiTiDz2F+Orv/+oHJR+PrGv+38oghCddpsW4YEZl5qyLsWxSwYUWrKEOfjpGtXDFW6scJtjpzSLeSw==",
+      "version": "0.24.38",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.38.tgz",
+      "integrity": "sha512-IbYB6vdhLFmzGEyXXEdFAJKyq7S4/RsivkgxNzs/LzwYuUJHmeNQ0cHkjG/Yqm6VgUzzZDLMZAf0XgeeaZAocA==",
       "dev": true
     },
     "@sindresorhus/is": {
@@ -12341,9 +12342,9 @@
       "optional": true
     },
     "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.1.tgz",
+      "integrity": "sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==",
       "requires": {}
     },
     "boxen": {
@@ -13686,9 +13687,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.242.tgz",
-      "integrity": "sha512-nPdgMWtjjWGCtreW/2adkrB2jyHjClo9PtVhR6rW+oxa4E4Wom642Tn+5LslHP3XPL5MCpkn5/UEY60EXylNeQ==",
+      "version": "1.4.243",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.243.tgz",
+      "integrity": "sha512-BgLD2gBX43OSXwlT01oYRRD5NIB4n3okTRxkzEAC6G0SZG4TTlyrWMjbOo0fajCwqwpRtMHXQNMjtRN6qpNtfw==",
       "dev": true
     },
     "emittery": {
@@ -16620,13 +16621,13 @@
       }
     },
     "promise-android-tools": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.11.tgz",
-      "integrity": "sha512-pW0IiMjqvjXxJvP2so08AO6kwPIPFscxNdMtC6VfwerCkmXdgPuBaG4nHYJeKkDc6/eJaTTxG1oZ6gqEh93lWA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/promise-android-tools/-/promise-android-tools-4.0.13.tgz",
+      "integrity": "sha512-fkCzf8jVE+U1J7O3o9cM251TNQUtnXk/MrUb4FG6yYZ6QZuODxDPvONSsFyu/NW2tZCHKivVHFCmB7IEwj5QYg==",
       "requires": {
-        "android-tools-bin": "^1.0.6",
+        "android-tools-bin": "^1.0.7",
         "cancelable-promise": "^3.2.3",
-        "fs-extra": "^10.0.1"
+        "fs-extra": "^10.1.0"
       },
       "dependencies": {
         "cancelable-promise": {
@@ -18348,10 +18349,11 @@
       }
     },
     "winston": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.1.tgz",
-      "integrity": "sha512-r+6YAiCR4uI3N8eQNOg8k3P3PqwAm20cLKlzVD9E66Ch39+LZC+VH1UKf9JemQj2B3QoUHfKD7Poewn0Pr3Y1w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
+      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
       "requires": {
+        "@colors/colors": "1.5.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ubports-installer",
-  "version": "0.9.6-beta",
+  "version": "0.9.7-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ubports-installer",
-      "version": "0.9.6-beta",
+      "version": "0.9.7-beta",
       "license": "GPL-3.0",
       "dependencies": {
         "7zip-min": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "7zip-min": "^1.4.3",
     "axios": "^0.27.2",
-    "bootstrap": "^5.2.0",
+    "bootstrap": "^5.2.1",
     "cancelable-promise": "^4.3.0",
     "commander": "^9.4.0",
     "electron-open-link-in-browser": "^1.0.2",
@@ -66,14 +66,14 @@
     "graphql": "^16.6.0",
     "open-cuts-reporter": "^1.0.2",
     "progressive-downloader": "^1.0.7",
-    "promise-android-tools": "^4.0.11",
+    "promise-android-tools": "^4.0.13",
     "ps-tree": "^1.2.0",
     "semver": "^7.3.7",
     "sudo-prompt": "^9.2.1",
     "svelte-markdown": "^0.2.3",
     "sveltestrap": "^5.9.0",
     "systeminformation": "^5.12.6",
-    "winston": "^3.8.1",
+    "winston": "^3.8.2",
     "yaml": "^2.1.1"
   },
   "arkit": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ubports-installer",
-  "version": "0.9.6-beta",
+  "version": "0.9.7-beta",
   "description": "The easy way to install Ubuntu Touch on UBports devices. A friendly cross-platform Installer for Ubuntu Touch. Just connect a supported device to your PC, follow the on-screen instructions and watch this awesome tool do all the rest.",
   "keywords": [
     "Ubuntu",


### PR DESCRIPTION
This PR marks version as `0.9.7-beta` to prepare for a new installer release.

It also updates dependencies once again, pulling in a new version of `promise-android-tools` (4.0.13), which has a fastboot getvar fix for windows devices as well as new reboot targets for adb.