### PR TITLE
Add AppImage arm64 build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         run: |
           node ./build.js -o linux -p deb -a x64
           node ./build.js -o linux -p AppImage -a x64
+          node ./build.js -o linux -p AppImage -a arm64
       - name: build macOS
         if: contains(runner.os, 'macOS')
         run: |


### PR DESCRIPTION
Apparently snap is already built for `arm64`, can we do AppImage too? I wanted to test macOS aarch64 too, but this might be problematic as the required library (`dmg-license`) is macOS only, so would require a macOS builder.