### PR TITLE
plugins: systemimage: sort channels by stability, nicer labels, no edge

### DIFF
--- a/src/core/plugins/systemimage/api.js
+++ b/src/core/plugins/systemimage/api.js
@@ -86,31 +86,28 @@ const getImages = (channel, device, wipe, enable = [], disable = []) =>
 /**
  * get channels from api
  * @param {String} device device codename
- * @returns {Promise<Array<String>>} channels
+ * @returns {Promise<Array<Object>>} channels
  * @throws {Error} message "unsupported" if 404 not found
  */
-const getChannels = device =>
-  api
-    .get("channels.json")
-    .then(({ data }) => Object.entries(data))
-    .then(channels =>
-      channels
-        .filter(
-          ([name, properties]) =>
-            !(
-              (
-                !properties ||
-                properties.redirect ||
-                (properties.alias && properties.hidden) ||
-                !properties.devices
-              ) // remove invalid channels
-            ) && properties.devices[device] // remove channels that don't serve this device
-        )
-        .map(([name, properties]) => ({
-          value: name,
-          label: name.replace("ubports-touch/", ""),
-          hidden: properties.hidden || false
-        }))
-    );
+async function getChannels(device) {
+  const { data } = await api.get("channels.json");
+  return Object.entries(data)
+    .filter(
+      ([name, properties]) =>
+        !(
+          (
+            !properties ||
+            properties.redirect ||
+            (properties.alias && properties.hidden) ||
+            !properties.devices
+          ) // remove invalid channels
+        ) && properties.devices[device] // remove channels that don't serve this device
+    )
+    .map(([name, properties]) => ({
+      value: name,
+      label: name.replace("ubports-touch/", ""),
+      hidden: properties.hidden || false
+    }));
+}
 
 module.exports = { getImages, getChannels };

--- a/src/core/plugins/systemimage/plugin.js
+++ b/src/core/plugins/systemimage/plugin.js
@@ -21,6 +21,18 @@ const path = require("path");
 const Plugin = require("../plugin.js");
 const api = require("./api.js");
 
+const SORT_ORDER = ["stable", "rc", "devel"];
+
+/**
+ * Gets a sorting weight for a channel
+ * @param {String} channel the channel name
+ * @returns {Number} channel weight for sorting
+ */
+function getChannelWeight(channel) {
+  const parts = channel.split("/");
+  return SORT_ORDER.indexOf(parts[parts.length - 1]);
+}
+
 /**
  * systemimage plugin
  * @extends Plugin
@@ -87,22 +99,53 @@ class SystemimagePlugin extends Plugin {
    * channels remote_values
    * @returns {Promise<Array<Object>>}
    */
-  remote_values__channels() {
-    return api
-      .getChannels(this.props.config.codename)
-      .then(channels => ({
-        visible: channels.filter(({ hidden }) => !hidden).reverse(),
-        hidden: this.settings.get("systemimage.showHiddenChannels")
-          ? channels.filter(({ hidden }) => hidden)
-          : []
-      }))
-      .then(({ visible, hidden }) => [
-        ...visible.map(({ value, label }) => ({ value, label })),
-        ...(hidden.length
-          ? [{ label: "--- hidden channels ---", disabled: true }]
-          : []),
-        ...hidden.map(({ value, label }) => ({ value, label }))
-      ]);
+  async remote_values__channels() {
+    const channels = await api.getChannels(this.props.config.codename);
+    const sortedByStability = channels.sort((a, b) => {
+      const weight = getChannelWeight(a.value) - getChannelWeight(b.value);
+      if (weight !== 0) {
+        return weight;
+      }
+
+      // if stability is the same, sort descending by version number
+      const aVersion = parseFloat(a.value.split("/")[0]) || 0;
+      const bVersion = parseFloat(b.value.split("/")[0]) || 0;
+      return bVersion - aVersion;
+    });
+    const versionOrder = Array.from(
+      new Set(sortedByStability.map(({ value }) => value.split("/")[0]))
+    );
+    // second sort to group the versions together and make sure the latest one with stable is on the top
+    const sorted = channels.sort((a, b) => {
+      const aVersion = a.value.split("/")[0];
+      const bVersion = b.value.split("/")[0];
+
+      return versionOrder.indexOf(aVersion) - versionOrder.indexOf(bVersion);
+    });
+    const visible = sorted
+      .filter(({ value, hidden }) => !hidden && !value.endsWith("/edge"))
+      .map(({ value, label }) => {
+        if (value !== label) {
+          return { value, label };
+        }
+
+        const split = value.split("/");
+        return {
+          label: `${split[0]}/${split[split.length - 1]}`,
+          value
+        };
+      });
+    const hidden = this.settings.get("systemimage.showHiddenChannels")
+      ? sorted.filter(({ hidden }) => hidden)
+      : [];
+
+    return [
+      ...visible.map(({ value, label }) => ({ value, label })),
+      ...(hidden.length
+        ? [{ label: "--- hidden channels ---", disabled: true }]
+        : []),
+      ...hidden.map(({ value, label }) => ({ value, label }))
+    ];
   }
 }
 

--- a/src/core/plugins/systemimage/plugin.spec.js
+++ b/src/core/plugins/systemimage/plugin.spec.js
@@ -121,6 +121,90 @@ describe("systemimage plugin", () => {
             ])
           );
       });
+      it("should sort the channels based on stability", async () => {
+        api.getChannels.mockResolvedValueOnce([
+          {
+            hidden: false,
+            label: "20.04/rc",
+            value: "20.04/arm64/android9plus/rc"
+          },
+          {
+            hidden: false,
+            label: "16.04/stable",
+            value: "16.04/arm64/android9/stable"
+          },
+          {
+            hidden: false,
+            label: "16.04/rc",
+            value: "16.04/arm64/android9/rc"
+          }
+        ]);
+
+        const res = await systemimage.remote_values__channels();
+        expect(res).toEqual([
+          { label: "16.04/stable", value: "16.04/arm64/android9/stable" },
+          { label: "16.04/rc", value: "16.04/arm64/android9/rc" },
+          { label: "20.04/rc", value: "20.04/arm64/android9plus/rc" }
+        ]);
+      });
+      it("should rename labels when they are equal to values", async () => {
+        api.getChannels.mockResolvedValueOnce([
+          {
+            hidden: false,
+            label: "20.04/arm64/android9plus/rc",
+            value: "20.04/arm64/android9plus/rc"
+          },
+          {
+            hidden: false,
+            label: "16.04/arm64/android9/stable",
+            value: "16.04/arm64/android9/stable"
+          },
+          {
+            hidden: false,
+            label: "16.04/arm64/android9/rc",
+            value: "16.04/arm64/android9/rc"
+          }
+        ]);
+
+        const res = await systemimage.remote_values__channels();
+        expect(res).toEqual([
+          { label: "16.04/stable", value: "16.04/arm64/android9/stable" },
+          { label: "16.04/rc", value: "16.04/arm64/android9/rc" },
+          { label: "20.04/rc", value: "20.04/arm64/android9plus/rc" }
+        ]);
+      });
+      it("should sort higher stable versions first", async () => {
+        api.getChannels.mockResolvedValueOnce([
+          {
+            hidden: false,
+            label: "16.04/arm64/android9/stable",
+            value: "16.04/arm64/android9/stable"
+          },
+          {
+            hidden: false,
+            label: "16.04/arm64/android9/rc",
+            value: "16.04/arm64/android9/rc"
+          },
+          {
+            hidden: false,
+            label: "20.04/arm64/android9plus/rc",
+            value: "20.04/arm64/android9plus/rc"
+          },
+          {
+            hidden: false,
+            label: "20.04/arm64/android9plus/stable",
+            value: "20.04/arm64/android9plus/stable"
+          }
+        ]);
+
+        const res = await systemimage.remote_values__channels();
+        expect(res).toEqual([
+          { label: "20.04/stable", value: "20.04/arm64/android9plus/stable" },
+          { label: "20.04/rc", value: "20.04/arm64/android9plus/rc" },
+          { label: "16.04/stable", value: "16.04/arm64/android9/stable" },
+          { label: "16.04/rc", value: "16.04/arm64/android9/rc" }
+        ]);
+      });
     });
   });
 });


### PR DESCRIPTION
This makes the channel list sort by stability (grouped by major version)
to avoid the unstable latest one being the default which confuses new
users.

Also makes labels shorter by removing the arch/halium version from the
name.

And hides /edge to avoid further confusion.