### PR TITLE
plugins: lineage: select latest build instead of oldest

### DIFF
--- a/src/core/plugins/lineage_os/api.js
+++ b/src/core/plugins/lineage_os/api.js
@@ -40,9 +40,9 @@ const getLatestBuild = (channel, device) =>
     .then(({ data }) => {
       return [
         {
-          url: data.response[data.response.length - 1].url,
+          url: data.response[0].url,
           checksum: {
-            sum: data.response[data.response.length - 1].id,
+            sum: data.response[0].id,
             algorithm: "sha256"
           },
           name: rootfsDefaultName + device + ".zip"

--- a/src/core/plugins/lineage_os/api.spec.js
+++ b/src/core/plugins/lineage_os/api.spec.js
@@ -20,8 +20,8 @@ describe("lineage_os api", () => {
       return api.getLatestBuild("nightlies", "bacon").then(r =>
         expect(r).toEqual([
           {
-            checksum: { algorithm: "sha256", sum: "1337" },
-            url: "b",
+            checksum: { algorithm: "sha256", sum: "42" },
+            url: "a",
             name: "lineageos_rootfs_bacon.zip"
           }
         ])


### PR DESCRIPTION
The response is sorted from newest to oldest version. We are selecting the last entry (length - 1), which is the oldest version.

This results in devices with support for multiple lineage versions (eg 19.1, 20.0) to retrieve the older version (eg 19.1) which is in most cases unsupported.

If the device only supports a single version, it selects older builds as well, which will ask to update again.

Use the first entry of the response to install the latest version.

Fixes: https://github.com/ubports/ubports-installer/issues/3141