### PR TITLE
lib: updater: fix semver comparison

### DIFF
--- a/src/lib/updater.js
+++ b/src/lib/updater.js
@@ -19,6 +19,8 @@
 
 const axios = require("axios");
 const packageInfo = require("../../package.json");
+const semverGt = require("semver/functions/gt");
+const semverLt = require("semver/functions/lt");
 
 /**
  * UBports Installer version management
@@ -64,20 +66,18 @@ class Updater {
    * resolves update url if the installer is outdated, null otherwise
    * @returns {Promise<String>}
    */
-  isOutdated() {
-    return this.getLatestVersion().then(latest =>
-      packageInfo.version < latest ? this.updateUrl : null
-    );
+  async isOutdated() {
+    const latest = await this.getLatestVersion();
+    return semverLt(packageInfo.version, latest) ? this.updateUrl : null;
   }
 
   /**
    * resolves update url if the installer is a prerelease, null otherwise
    * @returns {Promise<String>}
    */
-  isPrerelease() {
-    return this.getLatestVersion().then(latest =>
-      packageInfo.version > latest ? this.updateUrl : null
-    );
+  async isPrerelease() {
+    const latest = await this.getLatestVersion();
+    return semverGt(packageInfo.version, latest) ? this.updateUrl : null;
   }
 }
 


### PR DESCRIPTION
Fixes the comparison in updater to be semver-compatible.

I'd recommend bumping the version to `0.10.0` to make versions `0.9.2`-`0.9.9` show the update prompt.

Keep in mind that in semver `0.0.1` is more recent than `0.0.1-beta` - and we should make sure the `package.json` version is in sync with the tag names, it will always scream for an update if it's a `0.10.0` tag and `0.10.0-beta` in `package.json`