### PR TITLE
core: re-create plugin index on reset

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -49,16 +49,7 @@ const semver = require("semver");
 class Core {
   constructor() {
     this.session = new Session();
-    this.props = {};
     this.reset();
-    this.plugins = new PluginIndex(
-      this.props,
-      cachePath,
-      mainEvent,
-      log,
-      settings,
-      this.session
-    );
   }
 
   /**
@@ -71,6 +62,14 @@ class Core {
       os: null,
       settings: {}
     };
+    this.plugins = new PluginIndex(
+      this.props,
+      cachePath,
+      mainEvent,
+      log,
+      settings,
+      this.session
+    );
   }
 
   /**


### PR DESCRIPTION
Looks like this is the last thing that has to be reset.