### PR TITLE
deps: downgrade progressive-downloader to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "fs-extra": "^11.1.0",
         "graphql": "^16.6.0",
         "open-cuts-reporter": "^1.0.2",
-        "progressive-downloader": "^2.0.2",
+        "progressive-downloader": "1.0.7",
         "promise-android-tools": "^4.0.13",
         "ps-tree": "^1.2.0",
         "semver": "^7.3.8",
@@ -2622,7 +2622,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -3215,6 +3214,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/checksum": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/checksum/-/checksum-0.1.1.tgz",
+      "integrity": "sha512-xWkkJpoWQ6CptWw2GvtoQbScL3xtvGjoqvHpALE7B0tSHxSw0ex0tlsKOKkbETaOYGBhMliAyscestDyAZIN9g==",
+      "dependencies": {
+        "optimist": "~0.3.5"
+      },
+      "bin": {
+        "checksum": "bin/checksum-cli.js"
       }
     },
     "node_modules/chokidar": {
@@ -7835,6 +7845,14 @@
         "graphql-request": "^3.5.0"
       }
     },
+    "node_modules/optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
+      "dependencies": {
+        "wordwrap": "~0.0.2"
+      }
+    },
     "node_modules/opts": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
@@ -8341,12 +8359,36 @@
       }
     },
     "node_modules/progressive-downloader": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/progressive-downloader/-/progressive-downloader-2.0.2.tgz",
-      "integrity": "sha512-v0pSo3Av65V4nhWGTN676jF/fUlmP+d41YkvtCGnWA4no0x1x94eIp/ubZcI7SwKB/1ZfICRCXRcVOKILprU0A==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/progressive-downloader/-/progressive-downloader-1.0.7.tgz",
+      "integrity": "sha512-DmPoDRfSGV4zD5wCwD4IwbvZWuSqyakQWFRrstEwI7JNwSzvM//1+3rQRVADnGa+jnNJjz0DpRfWHIqb3n+Wow==",
       "dependencies": {
-        "axios": "^1.2.0",
-        "tslib": "^2.4.1"
+        "@babel/runtime": "^7.11.2",
+        "axios": "^0.21.1",
+        "checksum": "^0.1.1",
+        "fs-extra": "^9.0.1"
+      }
+    },
+    "node_modules/progressive-downloader/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/progressive-downloader/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/promise-android-tools": {
@@ -10188,11 +10230,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -10545,6 +10582,14 @@
       },
       "engines": {
         "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -12712,8 +12757,7 @@
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -13142,6 +13186,14 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "checksum": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/checksum/-/checksum-0.1.1.tgz",
+      "integrity": "sha512-xWkkJpoWQ6CptWw2GvtoQbScL3xtvGjoqvHpALE7B0tSHxSw0ex0tlsKOKkbETaOYGBhMliAyscestDyAZIN9g==",
+      "requires": {
+        "optimist": "~0.3.5"
+      }
     },
     "chokidar": {
       "version": "3.5.3",
@@ -16706,6 +16758,14 @@
         "graphql-request": "^3.5.0"
       }
     },
+    "optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
+      "requires": {
+        "wordwrap": "~0.0.2"
+      }
+    },
     "opts": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
@@ -17079,12 +17139,35 @@
       "dev": true
     },
     "progressive-downloader": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/progressive-downloader/-/progressive-downloader-2.0.2.tgz",
-      "integrity": "sha512-v0pSo3Av65V4nhWGTN676jF/fUlmP+d41YkvtCGnWA4no0x1x94eIp/ubZcI7SwKB/1ZfICRCXRcVOKILprU0A==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/progressive-downloader/-/progressive-downloader-1.0.7.tgz",
+      "integrity": "sha512-DmPoDRfSGV4zD5wCwD4IwbvZWuSqyakQWFRrstEwI7JNwSzvM//1+3rQRVADnGa+jnNJjz0DpRfWHIqb3n+Wow==",
       "requires": {
-        "axios": "^1.2.0",
-        "tslib": "^2.4.1"
+        "@babel/runtime": "^7.11.2",
+        "axios": "^0.21.1",
+        "checksum": "^0.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "promise-android-tools": {
@@ -18515,11 +18598,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -18795,6 +18873,11 @@
         "readable-stream": "^3.6.0",
         "triple-beam": "^1.3.0"
       }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "fs-extra": "^11.1.0",
     "graphql": "^16.6.0",
     "open-cuts-reporter": "^1.0.2",
-    "progressive-downloader": "^2.0.2",
+    "progressive-downloader": "1.0.7",
     "promise-android-tools": "^4.0.13",
     "ps-tree": "^1.2.0",
     "semver": "^7.3.8",


### PR DESCRIPTION
Version 2.x has issues with bigger files, probably due to reading the whole file at once instead of streaming - quick patch to fix installation for some devices while we look into it (that's one of our packages too).