### PR TITLE
postmarketos: use pretty_name for display labels

### DIFF
--- a/src/core/plugins/postmarketos/api.js
+++ b/src/core/plugins/postmarketos/api.js
@@ -39,13 +39,8 @@ const getInterfaces = device =>
       const devices = data.releases.find(c => c.name === "edge").devices;
       const interfaces = devices
         .find(d => d.name.includes(device))
-        .interfaces.map(i => i.name);
-      return interfaces.map(i => {
-        if (i === "phosh") return { value: i, label: "Phosh" };
-        if (i === "plasma-mobile") return { value: i, label: "Plasma Mobile" };
-        if (i === "sxmo-de-sway") return { value: i, label: "SXMO Sway" };
-        return { value: i, label: i };
-      });
+        .interfaces.map(i => ({ value: i.name, label: i.pretty_name }));
+      return interfaces;
     })
     .catch(error => {
       if (error?.response?.status === 404) throw new Error("404");
@@ -97,7 +92,7 @@ const getReleases = device =>
       const releases = data.releases;
       return releases
         .filter(release => release.devices.find(d => d.name.includes(device)))
-        .map(release => release.name);
+        .map(i => ({ value: i.name, label: i.pretty_name }));
     })
     .catch(error => {
       if (error?.response?.status === 404) throw new Error("404");

--- a/src/core/plugins/postmarketos/api.spec.js
+++ b/src/core/plugins/postmarketos/api.spec.js
@@ -7,13 +7,19 @@ const MOCK_DATA = {
   releases: [
     {
       name: "edge",
+      pretty_name: "edge (unsupported)",
       devices: [
         {
           name: "somedevice",
+          pretty_name: "Some Device",
           interfaces: [
-            { name: "phosh" },
+            {
+                name: "phosh",
+                pretty_name: "Phosh"
+            },
             {
               name: "plasma-mobile",
+              pretty_name: "Plasma Mobile",
               images: [
                 {
                   timestamp: 0,
@@ -27,8 +33,14 @@ const MOCK_DATA = {
                 }
               ]
             },
-            { name: "sxmo-de-sway" },
-            { name: "other" }
+            {
+                name: "sxmo-de-sway",
+                pretty_name: "Sxmo (Sway)"
+            },
+            {
+                name: "other",
+                pretty_name: "Other"
+            }
           ]
         }
       ]
@@ -56,11 +68,11 @@ describe("postmarketos api", () => {
       });
       expect(result).toContainEqual({
         value: "sxmo-de-sway",
-        label: "SXMO Sway"
+        label: "Sxmo (Sway)"
       });
       expect(result).toContainEqual({
         value: "other",
-        label: "other"
+        label: "Other"
       });
     });
 
@@ -111,7 +123,7 @@ describe("postmarketos api", () => {
   describe("getReleases()", () => {
     it("should resolve releases", async () => {
       const result = await api.getReleases("somedevice");
-      expect(result).toEqual(["edge"]);
+      expect(result).toEqual([{"label": "edge (unsupported)", "value": "edge"}]);
     });
 
     it("should throw on 404", async () => {

--- a/src/core/plugins/postmarketos/plugin.js
+++ b/src/core/plugins/postmarketos/plugin.js
@@ -117,13 +117,7 @@ class PostmarketOSPlugin extends Plugin {
    */
   remote_values__releases() {
     return api
-      .getReleases(this.props.os.codename ?? this.props.config.codename)
-      .then(releases =>
-        releases.map(release => ({
-          value: release,
-          label: release
-        }))
-      );
+      .getReleases(this.props.os.codename ?? this.props.config.codename);
   }
 }
 

--- a/src/core/plugins/postmarketos/plugin.spec.js
+++ b/src/core/plugins/postmarketos/plugin.spec.js
@@ -100,15 +100,16 @@ describe("postmarketos plugin", () => {
 
   describe("remote_values__releases()", () => {
     it("should get releases", async () => {
-      api.getReleases.mockResolvedValueOnce(["a", "b"]);
+      api.getReleases.mockResolvedValueOnce([{value: "a", label: "aA"},
+                                             {value: "b", label: "bB"}]);
       const result = await pmosPlugin.remote_values__releases();
       expect(api.getReleases).toHaveBeenCalledWith("os_codename");
       expect(result).toContainEqual({
-        label: "a",
+        label: "aA",
         value: "a"
       });
       expect(result).toContainEqual({
-        label: "b",
+        label: "bB",
         value: "b"
       });
     });


### PR DESCRIPTION
BPO now has pretty_name fields for interfaces, releases (and devices). Use them and remove the hardcoded UI name mappings.