### PR TITLE
feat(darwin-arm64): Adding support Mac M1 devices.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
         if: contains(runner.os, 'macOS')
         run: |
           node ./build.js -o darwin -p dmg -a x64
+          node ./build.js -o darwin -p dmg -a arm64
       - name: build windows
         if: contains(runner.os, 'Windows')
         run: |


### PR DESCRIPTION
This PR introduces support for Mac M1 devices in the UBports Installer. With this update, users on Apple’s ARM-based architecture can now easily install Ubuntu Touch on supported devices.