### PR TITLE
plugins: postmarketOS: allow passing in kernel variant

### DIFF
--- a/src/core/plugins/postmarketos/api.js
+++ b/src/core/plugins/postmarketos/api.js
@@ -52,10 +52,11 @@ const getInterfaces = device =>
  * @param {String} release release
  * @param {String} ui user interface
  * @param {String} device device codename
+ * @param {String} optional kernel variant
  * @returns {Promise<Array<Object>>} images array
  * @throws {Error} message "no network" if request failed
  */
-const getImages = (release, ui, device) =>
+const getImages = (release, ui, device, variant = "") =>
   api
     .get("/bpo/index.json")
     .then(({ data }) => {
@@ -65,7 +66,10 @@ const getImages = (release, ui, device) =>
       // The first two are the latest rootfs and boot image
       const ts_latest = images[0].timestamp;
       return images
-        .filter(i => i.timestamp === ts_latest)
+        .filter(i => variant
+          ? i.url.includes(`${device}-${variant}`) && i.timestamp === ts_latest
+          : i.timestamp === ts_latest
+        )
         .map(i => ({
           url: i.url,
           checksum: {

--- a/src/core/plugins/postmarketos/api.spec.js
+++ b/src/core/plugins/postmarketos/api.spec.js
@@ -94,7 +94,7 @@ describe("postmarketos api", () => {
 
   describe("getImages()", () => {
     it("should resolve images", async () => {
-      const result = await api.getImages("edge", "plasma-mobile", "somedevice");
+      const result = await api.getImages("edge", "plasma-mobile", "somedevice", "somevariant");
       expect(result).toContainEqual({
         url: "someurl",
         checksum: {
@@ -112,7 +112,7 @@ describe("postmarketos api", () => {
         }
       });
 
-      const test = () => api.getImages("non", "existent", "stuff");
+      const test = () => api.getImages("non", "existent", "stuff", "here");
       await expect(test).rejects.toThrow("404");
 
       axios.get.mockRejectedValueOnce(new Error("other"));

--- a/src/core/plugins/postmarketos/plugin.js
+++ b/src/core/plugins/postmarketos/plugin.js
@@ -37,7 +37,8 @@ class PostmarketOSPlugin extends Plugin {
       .getImages(
         this.props.settings["release"],
         this.props.settings["interface"],
-        this.props.os.codename ?? this.props.config.codename
+        this.props.os.codename ?? this.props.config.codename,
+        this.props.settings["variant"] ?? ""
       )
       .then(files => [
         {

--- a/src/core/plugins/postmarketos/plugin.spec.js
+++ b/src/core/plugins/postmarketos/plugin.spec.js
@@ -16,7 +16,8 @@ const pmosPlugin = new (require("./plugin.js"))(
   {
     settings: {
       release: "somerelease",
-      interface: "someinterface"
+      interface: "someinterface",
+      variant: "somevariant"
     },
     config: {
       codename: "config_codename"
@@ -40,7 +41,8 @@ describe("postmarketos plugin", () => {
       expect(api.getImages).toHaveBeenCalledWith(
         "somerelease",
         "someinterface",
-        "os_codename"
+        "os_codename",
+        "somevariant"
       );
       expect(ret[0]).toBeDefined();
       expect(ret[0].actions).toContainEqual({


### PR DESCRIPTION
This is required for devices that have different display panels, for example.

The variant parameter is kept optional to not break compatibility with current installer configs.