### PR TITLE
Remove dependency on gconf

### DIFF
--- a/build.js
+++ b/build.js
@@ -117,7 +117,6 @@ switch (opts.os) {
       deb: {
         depends: [
           "libnotify4",
-          "libappindicator1",
           "libxtst6",
           "libnss3",
           "android-tools-adb",


### PR DESCRIPTION
As per feedback from Telegram testers on certain Linux flavors the installer wont work due to its dependency on GConf. Lets just drop that and hope it is really not needed.