### PR TITLE
main: fix launching external links

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -85,7 +85,7 @@ async function createWindow() {
   // Make sure links are opened in browser
   mainWindow.webContents.on("will-navigate", (e, url) => {
     // TODO replace all the shell.openExternal calls in the svelte code with href's
-    if (url !== e.sender.getURL()) {
+    if (url !== mainWindow.webContents.getURL()) {
       e.preventDefault();
       shell.openExternal(url).then(() => {
         log.verbose("Opened external: " + url);


### PR DESCRIPTION
This was a breaking change already in Electron 25 which was not noticed after 9b0cca3 but until now with 0.11.0 finally releasing.

Fixes #4076.