### PR TITLE
.github: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @amartinz
-* @Flohack74
-* @maciek134
+* @amartinz @Flohack74 @maciek134


### PR DESCRIPTION
All owners need to be in a single line, otherwise it will override the previous lines.

Fixes: 1225af5a8e6ead9937c18ebd47b5d79f715304ef