### PR TITLE
properly escape paths for ADB, Fastboot and Heimdall

### DIFF
--- a/src/core/helpers/fileutil.js
+++ b/src/core/helpers/fileutil.js
@@ -29,10 +29,10 @@ const path = require("path");
  * @param file The actual file
  * @returns {string}
  */
-const buildPath = (basepath, codename, group, file) => {
+const buildPathForTools = (basepath, codename, group, file) => {
   return path.join(basepath, codename, group, file);
 };
 
 module.exports = {
-  buildPath
+  buildPathForTools
 };

--- a/src/core/helpers/fileutil.spec.js
+++ b/src/core/helpers/fileutil.spec.js
@@ -1,9 +1,9 @@
 const path = require("path");
 const fileutil = require("./fileutil.js");
 
-describe("buildPath()", () => {
+describe("buildPathForTools()", () => {
   it("should return normal path", () => {
-    const builtPath = fileutil.buildPath(
+    const builtPath = fileutil.buildPathForTools(
       "cache",
       "axolotl",
       "firmware",
@@ -16,7 +16,7 @@ describe("buildPath()", () => {
     expect(builtPath).toEqual(expectedPath);
   });
   it("should path with whitespaces within items", () => {
-    const builtPath = fileutil.buildPath(
+    const builtPath = fileutil.buildPathForTools(
       "cache   directory",
       "otter",
       "Ubuntu Touch",
@@ -30,7 +30,7 @@ describe("buildPath()", () => {
     expect(builtPath).toEqual(expectedPath);
   });
   it("should path with whitespaces around items", () => {
-    const builtPath = fileutil.buildPath(
+    const builtPath = fileutil.buildPathForTools(
       "  cache  ",
       "  otter  ",
       "  UbuntuTouch  ",
@@ -45,7 +45,7 @@ describe("buildPath()", () => {
   });
 
   it("should path with whitespaces within and around items", () => {
-    const builtPath = fileutil.buildPath(
+    const builtPath = fileutil.buildPathForTools(
       "  cache   directory  ",
       "FP5",
       "  Ubuntu Touch  ",

--- a/src/core/plugins/adb/plugin.js
+++ b/src/core/plugins/adb/plugin.js
@@ -19,7 +19,7 @@
 
 const Plugin = require("../plugin.js");
 const { Adb } = require("../../helpers/asarLibs.js").DeviceTools;
-const { buildPath } = require("../../helpers/fileutil.js");
+const { buildPathForTools } = require("../../helpers/fileutil.js");
 
 /**
  * adb plugin
@@ -99,7 +99,12 @@ class AdbPlugin extends Plugin {
       );
       return this.adb
         .sideload(
-          buildPath(this.cachePath, this.props.config.codename, group, file),
+          buildPathForTools(
+            this.cachePath,
+            this.props.config.codename,
+            group,
+            file
+          ),
           p => this.event.emit("user:write:progress", p * 100)
         )
         .then(() => this.event.emit("user:write:progress", 0));
@@ -121,7 +126,12 @@ class AdbPlugin extends Plugin {
       return this.adb
         .push(
           files.map(file =>
-            buildPath(this.cachePath, this.props.config.codename, group, file)
+            buildPathForTools(
+              this.cachePath,
+              this.props.config.codename,
+              group,
+              file
+            )
           ),
           dest,
           p => this.event.emit("user:write:progress", p * 100)

--- a/src/core/plugins/adb/plugin.spec.js
+++ b/src/core/plugins/adb/plugin.spec.js
@@ -2,7 +2,7 @@ const mainEvent = { emit: jest.fn() };
 beforeEach(() => mainEvent.emit.mockReset());
 const log = require("../../../lib/log.js");
 jest.mock("../../../lib/log.js");
-const { buildPath } = require("../../helpers/fileutil.js");
+const { buildPathForTools } = require("../../helpers/fileutil.js");
 
 const adbPlugin = new (require("./plugin.js"))(
   { config: { codename: "bacon" } },
@@ -89,7 +89,7 @@ describe("adb plugin", () => {
           expect(adbPlugin.event.emit).toHaveBeenCalledTimes(5);
           expect(adbPlugin.adb.sideload).toHaveBeenCalledTimes(1);
           expect(adbPlugin.adb.sideload).toHaveBeenCalledWith(
-            buildPath(
+            buildPathForTools(
               adbPlugin.cachePath,
               adbPlugin.props.config.codename,
               "Ubuntu Touch",
@@ -140,7 +140,7 @@ describe("adb plugin", () => {
           expect(adbPlugin.adb.push).toHaveBeenCalledTimes(1);
           expect(adbPlugin.adb.push).toHaveBeenCalledWith(
             [
-              buildPath(
+              buildPathForTools(
                 adbPlugin.cachePath,
                 adbPlugin.props.config.codename,
                 "Ubuntu Touch",

--- a/src/core/plugins/fastboot/plugin.js
+++ b/src/core/plugins/fastboot/plugin.js
@@ -19,7 +19,7 @@
 
 const Plugin = require("../plugin.js");
 const { Fastboot } = require("../../helpers/asarLibs.js").DeviceTools;
-const { buildPath } = require("../../helpers/fileutil.js");
+const { buildPathForTools } = require("../../helpers/fileutil.js");
 
 /**
  * fastboot plugin
@@ -195,7 +195,7 @@ class FastbootPlugin extends Plugin {
           this.fastboot.flash(
             partitions.map(file => ({
               ...file,
-              file: buildPath(
+              file: buildPathForTools(
                 this.cachePath,
                 this.props.config.codename,
                 file.group,
@@ -270,7 +270,7 @@ class FastbootPlugin extends Plugin {
         "Wiping and repartitioning super partition using fastbootd"
       );
       return this.fastboot.wipeSuper(
-        buildPath(
+        buildPathForTools(
           this.cachePath,
           this.props.config.codename,
           image.group,
@@ -322,7 +322,12 @@ class FastbootPlugin extends Plugin {
       this.event.emit("user:write:status", "Rebooting");
       this.event.emit("user:write:under", "Your device is being rebooted...");
       return this.fastboot.boot(
-        buildPath(this.cachePath, this.props.config.codename, group, file),
+        buildPathForTools(
+          this.cachePath,
+          this.props.config.codename,
+          group,
+          file
+        ),
         partition
       );
     });
@@ -341,7 +346,12 @@ class FastbootPlugin extends Plugin {
         "Applying fastboot update zip. This may take a while..."
       );
       return this.fastboot.update(
-        buildPath(this.cachePath, this.props.config.codename, group, file),
+        buildPathForTools(
+          this.cachePath,
+          this.props.config.codename,
+          group,
+          file
+        ),
         this?.props?.settings?.wipe
       );
     });

--- a/src/core/plugins/fastboot/plugin.spec.js
+++ b/src/core/plugins/fastboot/plugin.spec.js
@@ -1,5 +1,5 @@
 const mainEvent = { emit: jest.fn() };
-const { buildPath } = require("../../helpers/fileutil.js");
+const { buildPathForTools } = require("../../helpers/fileutil.js");
 
 beforeEach(() => mainEvent.emit.mockReset());
 
@@ -59,7 +59,7 @@ describe("fastboot plugin", () => {
         .then(() => {
           expect(fastbootPlugin.fastboot.update).toHaveBeenCalledTimes(1);
           expect(fastbootPlugin.fastboot.update).toHaveBeenCalledWith(
-            buildPath(
+            buildPathForTools(
               fastbootPlugin.cachePath,
               fastbootPlugin.props.config.codename,
               "group with spaces  ",
@@ -150,7 +150,7 @@ describe("fastboot plugin", () => {
         .then(() => {
           expect(fastbootPlugin.fastboot.boot).toHaveBeenCalledTimes(1);
           expect(fastbootPlugin.fastboot.boot).toHaveBeenCalledWith(
-            buildPath(
+            buildPathForTools(
               fastbootPlugin.cachePath,
               fastbootPlugin.props.config.codename,
               "firm ware",
@@ -260,7 +260,7 @@ describe("fastboot plugin", () => {
           expect(fastbootPlugin.fastboot.flash).toHaveBeenCalledWith(
             [
               {
-                file: buildPath(
+                file: buildPathForTools(
                   fastbootPlugin.cachePath,
                   fastbootPlugin.props.config.codename,
                   "firm ware",
@@ -270,7 +270,7 @@ describe("fastboot plugin", () => {
                 partition: "dtbo"
               },
               {
-                file: buildPath(
+                file: buildPathForTools(
                   fastbootPlugin.cachePath,
                   fastbootPlugin.props.config.codename,
                   "firmware",
@@ -280,7 +280,7 @@ describe("fastboot plugin", () => {
                 partition: "recovery"
               },
               {
-                file: buildPath(
+                file: buildPathForTools(
                   fastbootPlugin.cachePath,
                   fastbootPlugin.props.config.codename,
                   "firmware",
@@ -474,7 +474,7 @@ describe("fastboot plugin", () => {
         })
         .then(() => {
           expect(fastbootPlugin.fastboot.wipeSuper).toHaveBeenCalledWith(
-            buildPath(
+            buildPathForTools(
               fastbootPlugin.cachePath,
               fastbootPlugin.props.config.codename,
               "group",
@@ -500,7 +500,7 @@ describe("fastboot plugin", () => {
         })
         .then(() => {
           expect(fastbootPlugin.fastboot.wipeSuper).toHaveBeenCalledWith(
-            buildPath(
+            buildPathForTools(
               fastbootPlugin.cachePath,
               fastbootPlugin.props.config.codename,
               "group with spaces   ",

--- a/src/core/plugins/heimdall/plugin.js
+++ b/src/core/plugins/heimdall/plugin.js
@@ -19,7 +19,7 @@
 
 const Plugin = require("../plugin.js");
 const { Heimdall } = require("../../helpers/asarLibs.js").DeviceTools;
-const { buildPath } = require("../../helpers/fileutil.js");
+const { buildPathForTools } = require("../../helpers/fileutil.js");
 
 /**
  * heimdall actions plugin
@@ -104,7 +104,7 @@ class HeimdallPlugin extends Plugin {
       return this.heimdall.flash(
         partitions.map(file => ({
           ...file,
-          file: buildPath(
+          file: buildPathForTools(
             this.cachePath,
             this.props.config.codename,
             file.group,

--- a/src/core/plugins/heimdall/plugin.spec.js
+++ b/src/core/plugins/heimdall/plugin.spec.js
@@ -1,6 +1,6 @@
 const mainEvent = { emit: jest.fn() };
 const log = { warn: jest.fn() };
-const { buildPath } = require("../../helpers/fileutil.js");
+const { buildPathForTools } = require("../../helpers/fileutil.js");
 
 beforeEach(() => {
   mainEvent.emit.mockReset();
@@ -69,7 +69,7 @@ describe("heimdall plugin", () => {
           expect(heimdallPlugin.heimdall.flash).toHaveBeenCalledTimes(1);
           expect(heimdallPlugin.heimdall.flash).toHaveBeenCalledWith([
             {
-              file: buildPath(
+              file: buildPathForTools(
                 heimdallPlugin.cachePath,
                 heimdallPlugin.props.config.codename,
                 "Ubuntu Touch",


### PR DESCRIPTION
Move building tool paths from the tool plugin itselves to an own fileutil helper.

This allows us to adjust paths if needed (and it will be needed with the bump of `promise-android-tools`).

As a nice side effect we also get more tests and coverage.