### PR TITLE
snap: Fetch heimdall-flash from apt

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,7 @@ parts:
       - libnss3
       - adb
       - fastboot
+      - heimdall-flash
       - p7zip-full
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
core20 has v1.4.2 available, the same as the prebuilt in the node modules.