### PR TITLE
snap: Use layouts to find android tools

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,14 @@ apps:
       - adb-support
       - raw-usb
 
+layout:
+  /bin/adb:
+    symlink: $SNAP/usr/bin/adb
+  /bin/fastboot:
+    symlink: $SNAP/usr/bin/fastboot
+  /bin/heimdall:
+    symlink: $SNAP/usr/bin/heimdall
+
 parts:
   ubports-installer:
     plugin: dump


### PR DESCRIPTION
Something executes adb with "execve(/bin/adb)" instead of one found in the package. Use layouts to provide symlinks to the android tools in "/bin".