### PR TITLE
snap: Use "/usr/bin" absolute path for layouts

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,11 +32,11 @@ apps:
       - raw-usb
 
 layout:
-  /bin/adb:
+  /usr/bin/adb:
     symlink: $SNAP/usr/bin/adb
-  /bin/fastboot:
+  /usr/bin/fastboot:
     symlink: $SNAP/usr/bin/fastboot
-  /bin/heimdall:
+  /usr/bin/heimdall:
     symlink: $SNAP/usr/bin/heimdall
 
 parts:


### PR DESCRIPTION
/bin is a symlink. Put symlinks in the target directory instead.

Hopefully prevents:
cannot update snap namespace: cannot open directory "/bin": not a directory