### PR TITLE
plugins/systemimage: group UT channels by releases based on metarelease

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "bootstrap": "^5.3.7",
         "cancelable-promise": "^4.3.1",
         "commander": "^12.1.0",
+        "dpkg-compare-versions": "^1.0.3",
         "electron-open-link-in-browser": "^1.0.2",
         "electron-store": "^8.2.0",
         "form-data": "^4.0.4",
@@ -4226,6 +4227,12 @@
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dpkg-compare-versions": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dpkg-compare-versions/-/dpkg-compare-versions-1.0.3.tgz",
+      "integrity": "sha512-iFzCz1i/b4cX5fhZLOtCJOC7vwZkGTArZGXELVFiX0SF/YQiZF9Vb+psneG1DTUmLlz2BRcuTF9i0xb+KxEP3w==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "bootstrap": "^5.3.7",
     "cancelable-promise": "^4.3.1",
     "commander": "^12.1.0",
+    "dpkg-compare-versions": "^1.0.3",
     "electron-open-link-in-browser": "^1.0.2",
     "electron-store": "^8.2.0",
     "form-data": "^4.0.4",

--- a/src/core/plugins/systemimage/api.js
+++ b/src/core/plugins/systemimage/api.js
@@ -18,11 +18,13 @@
  */
 
 const axios = require("axios");
+const https = require("https");
 const path = require("path");
 
 /** @module systemimage */
 
 const baseURL = require("../../../lib/cli.js").systemimage;
+const metareleaseURL = require("../../../lib/cli.js").metarelease;
 
 const api = axios.create({ baseURL, timeout: 60000 });
 
@@ -105,9 +107,29 @@ async function getChannels(device) {
     )
     .map(([name, properties]) => ({
       value: name,
-      label: name.replace("ubports-touch/", ""),
       hidden: properties.hidden || false
     }));
 }
 
-module.exports = { getImages, getChannels };
+/**
+ * Get Ubuntu Touch releases from metarelease.
+ * Sees https://releases.ubuntu-touch.io/schemas/meta-release.schema.json
+ * @returns {Promise<Array<Object>>} list of Ubuntu Touch releases
+ */
+async function getMetarelease() {
+  try {
+    const { data } = await axios.get(metareleaseURL, {
+      timeout: 60000,
+      // Worksaround https://github.com/nodejs/node/issues/54359
+      httpsAgent: new https.Agent({
+        autoSelectFamilyAttemptTimeout: 500
+      })
+    });
+
+    return data;
+  } catch (error) {
+    throw new Error(error?.response?.status || "no network");
+  }
+}
+
+module.exports = { getImages, getChannels, getMetarelease };

--- a/src/core/plugins/systemimage/api.spec.js
+++ b/src/core/plugins/systemimage/api.spec.js
@@ -135,12 +135,10 @@ unmount system",
           expect(r).toEqual([
             {
               hidden: false,
-              label: "16.04/stable",
               value: "ubports-touch/16.04/stable"
             },
             {
               hidden: true,
-              label: "17.04/stable",
               value: "17.04/stable"
             }
           ])

--- a/src/core/plugins/systemimage/plugin.js
+++ b/src/core/plugins/systemimage/plugin.js
@@ -18,20 +18,10 @@
  */
 
 const path = require("path");
+const compareVersions = require("dpkg-compare-versions");
+
 const Plugin = require("../plugin.js");
 const api = require("./api.js");
-
-const SORT_ORDER = ["stable", "rc", "devel"];
-
-/**
- * Gets a sorting weight for a channel
- * @param {String} channel the channel name
- * @returns {Number} channel weight for sorting
- */
-function getChannelWeight(channel) {
-  const parts = channel.split("/");
-  return SORT_ORDER.indexOf(parts[parts.length - 1]);
-}
 
 /**
  * systemimage plugin
@@ -100,52 +90,157 @@ class SystemimagePlugin extends Plugin {
    * @returns {Promise<Array<Object>>}
    */
   async remote_values__channels() {
-    const channels = await api.getChannels(this.props.config.codename);
-    const sortedByStability = channels.sort((a, b) => {
-      const weight = getChannelWeight(a.value) - getChannelWeight(b.value);
-      if (weight !== 0) {
-        return weight;
+    const showDevel = this.settings.get("systemimage.showDevelopmentReleases");
+    const showEol = this.settings.get("systemimage.showEolReleases");
+    const showHidden = this.settings.get("systemimage.showHiddenChannels");
+
+    const [channels, metarelease] = await Promise.all([
+      api.getChannels(this.props.config.codename),
+      api.getMetarelease()
+    ]);
+
+    const channelsParsed = channels.map(({ value, hidden }) => {
+      const prettyStabilities = {
+        stable: "Stable",
+        rc: "Release candidate",
+        devel: "Development",
+        daily: "Daily builds"
+      };
+
+      const seriesIndex = metarelease.findIndex(
+        ({ systemImageChannels }) => systemImageChannels[value]
+      );
+
+      if (seriesIndex == -1) {
+        return {
+          label: value,
+          value,
+          _hidden: hidden,
+          _seriesIndex: seriesIndex
+        };
       }
 
-      // if stability is the same, sort descending by version number
-      const aVersion = parseFloat(a.value.split("/")[0]) || 0;
-      const bVersion = parseFloat(b.value.split("/")[0]) || 0;
-      return bVersion - aVersion;
+      const series = metarelease[seriesIndex];
+      let stability = series.systemImageChannels[value].stability;
+
+      // XXX: for 16.04, 20.04 consistency
+      if (
+        stability == "daily" &&
+        compareVersions(series.series, "20.04") <= 0
+      ) {
+        stability = "devel";
+      }
+
+      const label = `${series.series} ${prettyStabilities[stability] || stability}`;
+
+      return {
+        label,
+        value,
+        _hidden: hidden,
+        _seriesIndex: seriesIndex,
+        _stability: stability
+      };
     });
-    const versionOrder = Array.from(
-      new Set(sortedByStability.map(({ value }) => value.split("/")[0]))
+
+    // Group channels by series
+    const STABILITY_ORDER = ["stable", "rc", "daily", "devel"];
+
+    let groups = [];
+    for (let i = 0; i < metarelease.length; i++) {
+      const grouped_values = channelsParsed
+        // Hidden channels will be handled last
+        .filter(({ _hidden, _seriesIndex }) => !_hidden && _seriesIndex == i)
+        .sort((a, b) => {
+          let aWeight = STABILITY_ORDER.indexOf(a._stability);
+          if (aWeight == -1) aWeight = STABILITY_ORDER.length;
+
+          let bWeight = STABILITY_ORDER.indexOf(b._stability);
+          if (bWeight == -1) bWeight = STABILITY_ORDER.length;
+
+          return aWeight - bWeight;
+        });
+
+      if (grouped_values.length > 0) {
+        const labelSuffix =
+          metarelease[i].supportStatus == "development"
+            ? " (Development release)"
+            : metarelease[i].supportStatus == "end-of-life"
+              ? " (End-of-life)"
+              : "";
+
+        groups.push({
+          label: `${metarelease[i].series}${labelSuffix}`,
+          grouped_values,
+          _seriesIndex: i
+        });
+      }
+    }
+
+    // Now sort series by its support status, then by version.
+    const SUPPORT_STATUS_ORDER = ["supported", "development", "end-of-life"];
+    groups.sort((a, b) => {
+      const aSeries = metarelease[a._seriesIndex];
+      const bSeries = metarelease[b._seriesIndex];
+
+      if (aSeries.supportStatus != bSeries.supportStatus) {
+        let aWeight = SUPPORT_STATUS_ORDER.indexOf(aSeries.supportStatus);
+        if (aWeight == -1) aWeight = SUPPORT_STATUS_ORDER.length;
+
+        let bWeight = SUPPORT_STATUS_ORDER.indexOf(bSeries.supportStatus);
+        if (bWeight == -1) bWeight = SUPPORT_STATUS_ORDER.length;
+
+        return aWeight - bWeight;
+      }
+
+      const versionCompare = compareVersions(aSeries.series, bSeries.series);
+      // For development releases, sort older, closer-to-release releases first.
+      // Otherwise sort newer releases first.
+      if (aSeries.supportStatus == "development") {
+        return versionCompare;
+      } else {
+        return -versionCompare;
+      }
+    });
+
+    // Filter devel and EoL releases unless requested or no other releases
+    // available.
+    // Idea: we already sort by stability above, so stability of the first group
+    // is what we want to display unconditionally.
+    groups = groups.filter(group => {
+      let { supportStatus } = metarelease[group._seriesIndex];
+      if (supportStatus === metarelease[groups[0]._seriesIndex].supportStatus) {
+        return true;
+      } else if (supportStatus === "development") {
+        return showDevel;
+      } else if (supportStatus == "end-of-life") {
+        return showEol;
+      } else {
+        // ???
+        return true;
+      }
+    });
+
+    // Mark the current release as such if it's a supported release.
+    if (groups.length > 0) {
+      const firstSeries = metarelease[groups[0]._seriesIndex];
+      if (firstSeries.supportStatus == "supported") {
+        groups[0].label += " (Current release)";
+      }
+    }
+
+    // Finally, include hidden and ungroupped channels
+    const others = channelsParsed.filter(
+      ({ _hidden, _seriesIndex }) =>
+        (_hidden && showHidden) || (!_hidden && _seriesIndex == -1)
     );
-    // second sort to group the versions together and make sure the latest one with stable is on the top
-    const sorted = channels.sort((a, b) => {
-      const aVersion = a.value.split("/")[0];
-      const bVersion = b.value.split("/")[0];
-
-      return versionOrder.indexOf(aVersion) - versionOrder.indexOf(bVersion);
-    });
-    const visible = sorted
-      .filter(({ value, hidden }) => !hidden && !value.endsWith("/edge"))
-      .map(({ value, label }) => {
-        if (value !== label) {
-          return { value, label };
-        }
-
-        const split = value.split("/");
-        return {
-          label: `${split[0]}/${split[split.length - 1]}`,
-          value
-        };
+    if (others.length > 0) {
+      groups.push({
+        label: "Others/hidden channels",
+        grouped_values: others
       });
-    const hidden = this.settings.get("systemimage.showHiddenChannels")
-      ? sorted.filter(({ hidden }) => hidden)
-      : [];
+    }
 
-    return [
-      ...visible.map(({ value, label }) => ({ value, label })),
-      ...(hidden.length
-        ? [{ label: "--- hidden channels ---", disabled: true }]
-        : []),
-      ...hidden.map(({ value, label }) => ({ value, label }))
-    ];
+    return groups;
   }
 }
 

--- a/src/core/plugins/systemimage/plugin.spec.js
+++ b/src/core/plugins/systemimage/plugin.spec.js
@@ -5,6 +5,86 @@ api.getImages.mockResolvedValue({
   files: [{ url: "a/s/d/f" }],
   commands: "here be dragons"
 });
+api.getMetarelease.mockResolvedValue([
+  {
+    series: "16.04",
+    supportStatus: "end-of-life",
+    systemImageChannels: {
+      "16.04/arm64/android9plus/devel": {
+        variant: "arm64/android9plus",
+        stability: "daily"
+      },
+      "16.04/arm64/android9plus/rc": {
+        variant: "arm64/android9plus",
+        stability: "rc"
+      },
+      "16.04/arm64/android9plus/stable": {
+        variant: "arm64/android9plus",
+        stability: "stable"
+      }
+    }
+  },
+  {
+    series: "20.04",
+    supportStatus: "supported",
+    systemImageChannels: {
+      "20.04/arm64/android9plus/devel": {
+        variant: "arm64/android9plus",
+        stability: "daily"
+      },
+      "20.04/arm64/android9plus/rc": {
+        variant: "arm64/android9plus",
+        stability: "rc"
+      },
+      "20.04/arm64/android9plus/stable": {
+        variant: "arm64/android9plus",
+        stability: "stable"
+      }
+    }
+  },
+  {
+    series: "24.04-1.x",
+    supportStatus: "supported",
+    systemImageChannels: {
+      "24.04-1.x/arm64/android9plus/daily": {
+        variant: "arm64/android9plus",
+        stability: "daily"
+      },
+      "24.04-1.x/arm64/android9plus/rc": {
+        variant: "arm64/android9plus",
+        stability: "rc"
+      },
+      "24.04-1.x/arm64/android9plus/stable": {
+        variant: "arm64/android9plus",
+        stability: "stable"
+      }
+    }
+  },
+  {
+    series: "24.04-2.x",
+    supportStatus: "development",
+    systemImageChannels: {
+      "24.04-2.x/arm64/android9plus/daily": {
+        variant: "arm64/android9plus",
+        stability: "daily"
+      },
+      "24.04-2.x/arm64/android9plus/rc": {
+        variant: "arm64/android9plus",
+        stability: "rc"
+      }
+    }
+  },
+  {
+    series: "26.04-1.x",
+    supportStatus: "development",
+    systemImageChannels: {
+      "26.04-1.x/arm64/android9plus/daily": {
+        variant: "arm64/android9plus",
+        stability: "daily"
+      }
+    }
+  }
+]);
 const systemimage = new (require("./plugin.js"))({
   os: { name: "Ubuntu Touch" },
   config: { codename: "bacon" },
@@ -61,148 +141,390 @@ describe("systemimage plugin", () => {
   });
   describe("remote_values", () => {
     describe("channels", () => {
-      it("should resolve channels", () => {
-        systemimage.settings.get.mockReturnValueOnce(false);
+      function mockSettings(showDevel, showEol, showHidden) {
+        const settings = {
+          "systemimage.showDevelopmentReleases": showDevel,
+          "systemimage.showEolReleases": showEol,
+          "systemimage.showHiddenChannels": showHidden
+        };
+
+        systemimage.settings.get.mockImplementation(key => settings[key]);
+      }
+
+      it("should group channels by series", async () => {
+        mockSettings(false, false, false);
         api.getChannels.mockResolvedValueOnce([
-          {
-            hidden: false,
-            label: "16.04/stable",
-            value: "ubports-touch/16.04/stable"
-          },
-          {
-            hidden: true,
-            label: "17.04/stable",
-            value: "17.04/stable"
-          }
-        ]);
-        return systemimage.remote_values__channels().then(r => {
-          expect(r).toEqual([
-            { label: "16.04/stable", value: "ubports-touch/16.04/stable" }
-          ]);
-          expect(systemimage.settings.get).toHaveBeenCalledTimes(1);
-        });
-      });
-      it("should resolve channels including hidden channels if set", () => {
-        systemimage.settings.get.mockReturnValueOnce(true);
-        api.getChannels.mockResolvedValueOnce([
-          {
-            hidden: false,
-            label: "16.04/stable",
-            value: "ubports-touch/16.04/stable"
-          },
-          {
-            hidden: true,
-            label: "17.04/stable",
-            value: "17.04/stable"
-          }
-        ]);
-        return systemimage.remote_values__channels().then(r => {
-          expect(r).toEqual([
-            { label: "16.04/stable", value: "ubports-touch/16.04/stable" },
-            { label: "--- hidden channels ---", disabled: true },
-            { label: "17.04/stable", value: "17.04/stable" }
-          ]);
-          expect(systemimage.settings.get).toHaveBeenCalledTimes(1);
-        });
-      });
-      it("should not include hidden channels separator if none specified", () => {
-        api.getChannels.mockResolvedValueOnce([
-          {
-            hidden: false,
-            label: "16.04/stable",
-            value: "ubports-touch/16.04/stable"
-          }
-        ]);
-        systemimage
-          .remote_values__channels()
-          .then(r =>
-            expect(r).toEqual([
-              { label: "16.04/stable", value: "ubports-touch/16.04/stable" }
-            ])
-          );
-      });
-      it("should sort the channels based on stability", async () => {
-        api.getChannels.mockResolvedValueOnce([
-          {
-            hidden: false,
-            label: "20.04/rc",
-            value: "20.04/arm64/android9plus/rc"
-          },
-          {
-            hidden: false,
-            label: "16.04/stable",
-            value: "16.04/arm64/android9/stable"
-          },
-          {
-            hidden: false,
-            label: "16.04/rc",
-            value: "16.04/arm64/android9/rc"
-          }
+          { value: "20.04/arm64/android9plus/devel", hidden: false }
         ]);
 
-        const res = await systemimage.remote_values__channels();
-        expect(res).toEqual([
-          { label: "16.04/stable", value: "16.04/arm64/android9/stable" },
-          { label: "16.04/rc", value: "16.04/arm64/android9/rc" },
-          { label: "20.04/rc", value: "20.04/arm64/android9plus/rc" }
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          })
         ]);
       });
-      it("should rename labels when they are equal to values", async () => {
+
+      it("should hide development and end-of-life releases by default", async () => {
+        mockSettings(false, false, false);
         api.getChannels.mockResolvedValueOnce([
-          {
-            hidden: false,
-            label: "20.04/arm64/android9plus/rc",
-            value: "20.04/arm64/android9plus/rc"
-          },
-          {
-            hidden: false,
-            label: "16.04/arm64/android9/stable",
-            value: "16.04/arm64/android9/stable"
-          },
-          {
-            hidden: false,
-            label: "16.04/arm64/android9/rc",
-            value: "16.04/arm64/android9/rc"
-          }
+          { value: "16.04/arm64/android9plus/devel", hidden: false },
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-2.x/arm64/android9plus/daily", hidden: false }
         ]);
 
-        const res = await systemimage.remote_values__channels();
-        expect(res).toEqual([
-          { label: "16.04/stable", value: "16.04/arm64/android9/stable" },
-          { label: "16.04/rc", value: "16.04/arm64/android9/rc" },
-          { label: "20.04/rc", value: "20.04/arm64/android9plus/rc" }
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          })
         ]);
       });
-      it("should sort higher stable versions first", async () => {
+
+      it("should show development releases if asked", async () => {
+        mockSettings(true, false, false);
         api.getChannels.mockResolvedValueOnce([
-          {
-            hidden: false,
-            label: "16.04/arm64/android9/stable",
-            value: "16.04/arm64/android9/stable"
-          },
-          {
-            hidden: false,
-            label: "16.04/arm64/android9/rc",
-            value: "16.04/arm64/android9/rc"
-          },
-          {
-            hidden: false,
-            label: "20.04/arm64/android9plus/rc",
-            value: "20.04/arm64/android9plus/rc"
-          },
-          {
-            hidden: false,
-            label: "20.04/arm64/android9plus/stable",
-            value: "20.04/arm64/android9plus/stable"
-          }
+          { value: "16.04/arm64/android9plus/devel", hidden: false },
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-2.x/arm64/android9plus/daily", hidden: false }
         ]);
 
-        const res = await systemimage.remote_values__channels();
-        expect(res).toEqual([
-          { label: "20.04/stable", value: "20.04/arm64/android9plus/stable" },
-          { label: "20.04/rc", value: "20.04/arm64/android9plus/rc" },
-          { label: "16.04/stable", value: "16.04/arm64/android9/stable" },
-          { label: "16.04/rc", value: "16.04/arm64/android9/rc" }
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          }),
+          expect.objectContaining({
+            label: "24.04-2.x (Development release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "24.04-2.x Daily builds",
+                value: "24.04-2.x/arm64/android9plus/daily"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should show development releases if there's no supported release", async () => {
+        mockSettings(false, false, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "16.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-2.x/arm64/android9plus/daily", hidden: false }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "24.04-2.x (Development release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "24.04-2.x Daily builds",
+                value: "24.04-2.x/arm64/android9plus/daily"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should show EoL'ed releases if asked", async () => {
+        mockSettings(false, true, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "16.04/arm64/android9plus/devel", hidden: false },
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-2.x/arm64/android9plus/daily", hidden: false }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          }),
+          expect.objectContaining({
+            label: "16.04 (End-of-life)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "16.04 Development",
+                value: "16.04/arm64/android9plus/devel"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should show EoL'ed releases if there's no other releases", async () => {
+        mockSettings(false, false, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "16.04/arm64/android9plus/devel", hidden: false }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "16.04 (End-of-life)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "16.04 Development",
+                value: "16.04/arm64/android9plus/devel"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should show supported releases before development releases, before EoL'ed releases", async () => {
+        mockSettings(true, true, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "16.04/arm64/android9plus/devel", hidden: false },
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-2.x/arm64/android9plus/daily", hidden: false }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          }),
+          expect.objectContaining({
+            label: "24.04-2.x (Development release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "24.04-2.x Daily builds",
+                value: "24.04-2.x/arm64/android9plus/daily"
+              })
+            ]
+          }),
+          expect.objectContaining({
+            label: "16.04 (End-of-life)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "16.04 Development",
+                value: "16.04/arm64/android9plus/devel"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should sort newer supported releases first", async () => {
+        mockSettings(false, false, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-1.x/arm64/android9plus/daily", hidden: false }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "24.04-1.x (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "24.04-1.x Daily builds",
+                value: "24.04-1.x/arm64/android9plus/daily"
+              })
+            ]
+          }),
+          expect.objectContaining({
+            label: "20.04",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should sort older (nearing release) development releases first", async () => {
+        mockSettings(false, false, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "26.04-1.x/arm64/android9plus/daily", hidden: false },
+          { value: "24.04-2.x/arm64/android9plus/daily", hidden: false }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "24.04-2.x (Development release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "24.04-2.x Daily builds",
+                value: "24.04-2.x/arm64/android9plus/daily"
+              })
+            ]
+          }),
+          expect.objectContaining({
+            label: "26.04-1.x (Development release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "26.04-1.x Daily builds",
+                value: "26.04-1.x/arm64/android9plus/daily"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should hide hidden channels by default", async () => {
+        mockSettings(false, false, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-1.x/arm64/android9plus/daily", hidden: true }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should show hidden channels separately if asked", async () => {
+        mockSettings(false, false, true);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-1.x/arm64/android9plus/daily", hidden: true }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          }),
+          expect.objectContaining({
+            label: "Others/hidden channels",
+            grouped_values: [
+              expect.objectContaining({
+                label: "24.04-1.x Daily builds",
+                value: "24.04-1.x/arm64/android9plus/daily"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should show unknown channels separately without asking", async () => {
+        mockSettings(false, false, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-1.x/experiment_mir2/daily", hidden: false }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          }),
+          expect.objectContaining({
+            label: "Others/hidden channels",
+            grouped_values: [
+              expect.objectContaining({
+                label: "24.04-1.x/experiment_mir2/daily",
+                value: "24.04-1.x/experiment_mir2/daily"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should not show unknown, hidden channels", async () => {
+        mockSettings(false, false, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "24.04-1.x/experiment_mir2/daily", hidden: true }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          })
+        ]);
+      });
+
+      it("should sort channels by stability", async () => {
+        mockSettings(false, false, false);
+        api.getChannels.mockResolvedValueOnce([
+          { value: "20.04/arm64/android9plus/devel", hidden: false },
+          { value: "20.04/arm64/android9plus/rc", hidden: false },
+          { value: "20.04/arm64/android9plus/stable", hidden: false }
+        ]);
+
+        const r = await systemimage.remote_values__channels();
+        expect(r).toEqual([
+          expect.objectContaining({
+            label: "20.04 (Current release)",
+            grouped_values: [
+              expect.objectContaining({
+                label: "20.04 Stable",
+                value: "20.04/arm64/android9plus/stable"
+              }),
+              expect.objectContaining({
+                label: "20.04 Release candidate",
+                value: "20.04/arm64/android9plus/rc"
+              }),
+              expect.objectContaining({
+                label: "20.04 Development",
+                value: "20.04/arm64/android9plus/devel"
+              })
+            ]
+          })
         ]);
       });
     });

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -54,6 +54,11 @@ cli
     "Set a custom systemimage server url",
     "https://system-image.ubports.com/"
   )
+  .option(
+    "--metarelease <url>",
+    "Set a custom Ubuntu Touch metarelease url",
+    "https://releases.ubuntu-touch.io/meta-release.json"
+  )
   .parse(process.argv);
 
 log.setLevel(cli.opts().verbose || 0);

--- a/src/lib/menuManager.js
+++ b/src/lib/menuManager.js
@@ -131,6 +131,26 @@ class MenuManager {
             }
           },
           {
+            label: "Show development Ubuntu Touch releases",
+            checked: settings.get("systemimage.showDevelopmentReleases"),
+            type: "checkbox",
+            click: () =>
+              settings.set(
+                "systemimage.showDevelopmentReleases",
+                !settings.get("systemimage.showDevelopmentReleases")
+              )
+          },
+          {
+            label: "Show end-of-life Ubuntu Touch releases",
+            checked: settings.get("systemimage.showEolReleases"),
+            type: "checkbox",
+            click: () =>
+              settings.set(
+                "systemimage.showEolReleases",
+                !settings.get("systemimage.showEolReleases")
+              )
+          },
+          {
             label: "Show hidden System-Image Channels",
             checked: settings.get("systemimage.showHiddenChannels"),
             type: "checkbox",

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -44,6 +44,14 @@ const settings = new Store({
       }
     },
     systemimage: {
+      showDevelopmentReleases: {
+        type: "boolean",
+        default: false
+      },
+      showEolReleases: {
+        type: "boolean",
+        default: false
+      },
       showHiddenChannels: {
         type: "boolean",
         default: false

--- a/src/ui/modals/specific-modals/PromptModals.svelte
+++ b/src/ui/modals/specific-modals/PromptModals.svelte
@@ -54,9 +54,21 @@
             {#if field.type === "select"}
               <select class="form-select" bind:value={formData[id][field.var]}>
                 {#each field.values as value}
-                  <option disabled={value.disabled} value={value.value}
-                    >{value.label}</option
-                  >
+                  {#if value.value}
+                    <option disabled={value.disabled} value={value.value}
+                      >{value.label}</option
+                    >
+                  {:else if value.grouped_values}
+                    <optgroup label={value.label} disabled={value.disabled}>
+                      {#each value.grouped_values as opt}
+                        <option disabled={opt.disabled} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      {/each}
+                    </optgroup>
+                  {:else}
+                    <option disabled=true>{value.label}</option>
+                  {/if}
                 {/each}
               </select>
             {:else if field.type === "checkbox"}


### PR DESCRIPTION
With the new UT major-minor release scheme, the number of channels
increases significantly. Group those channels by UT releases using
information from Ubuntu Touch metarelease file (the same file used by
release upgrader on Ubuntu Touch itself), and prioritize supported
releases over development and end-of-life releases.