### PR TITLE
Fix: npm run start script on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-terser": "^0.4.4",
+        "cross-env": "^7.0.3",
         "electron": "^33.4.11",
         "electron-builder": "^24.13.3",
         "electron-reload": "^1.5.0",
@@ -3923,6 +3924,25 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "npx rollup -c",
-    "start": "./start.sh",
+    "start": "cross-env-shell ./start.sh",
     "lint": "npx prettier \"**/!(*.min.*)\" --ignore-path=.gitignore --arrow-parens=avoid --trailing-comma=none -uw",
     "docs": "npx jsdoc -c jsdoc-config.json",
     "test": "npx jest --coverage"
@@ -37,6 +37,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.4",
+    "cross-env": "^7.0.3",
     "electron": "^33.4.11",
     "electron-builder": "^24.13.3",
     "electron-reload": "^1.5.0",


### PR DESCRIPTION
This code fixes #4286
I used [cross-env](https://www.npmjs.com/package/cross-env) lib to run `start.sh` script witch sets env.
`cross-env` uses `git bash` to run shell commands on windows but uses native shell on macOS.

<img width="4255" height="2755" alt="image" src="https://github.com/user-attachments/assets/10aa66dc-8a4f-400f-ac8a-c86e5122041b" />


Tested works on Windows 10 x64 and on MacOS 15.7.1 ARM64