### PR TITLE
core: Detect bootloader-locked MediaTek devices during flashing

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -378,7 +378,8 @@ class Core {
       return new Promise((resolve, reject) => mainEvent.emit("user:low-power"));
     } else if (
       error.message.includes("bootloader locked") ||
-      error.message.includes("enable unlocking")
+      error.message.includes("enable unlocking") ||
+      error.message.includes("by lock control")
     ) {
       return this.step(this.props.config.handlers.bootloader_locked).then(() =>
         this.step(step)


### PR DESCRIPTION
Otherwise flashing with locked bootloader will always just fail with `No support by lock control` message from LK instead of attempting e.g. `fastboot flashing unlock` from a potential handler.

Closes #3442
Closes #3621
Closes #4123
Closes #4225
Closes #4341