### PR TITLE
lib: include body in GitHub issue URL to pre-filled GitHub issue description

### DIFF
--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -243,7 +243,7 @@ class Reporter {
         let issueUrl =
           "https://github.com/ubports/ubports-installer/issues/new";
         if (data) {
-          issueUrl += `?title=${encodeURIComponent(data.title)}`;
+          issueUrl += `?title=${encodeURIComponent(data.title)}&body=${encodeURIComponent(body)}`;
         }
         shell.openExternal(issueUrl);
       })


### PR DESCRIPTION
When opening a bug report issue from the installer, the issue body is now included in the URL so the reporter's description is pre-filled in the GitHub issue form.