### PR TITLE
fix: unpack android-tools-bin for macOS ARM64 builds

### DIFF
--- a/build.js
+++ b/build.js
@@ -90,6 +90,7 @@ var buildConfig = {
     "node_modules/fs-extra/**/*", // for promise-android-tools
     "node_modules/cancelable-promise/**/*", // for promise-android-tools
     "node_modules/promise-android-tools/**/*", // for android-tools-bin
+    "node_modules/android-tools-bin/**/*", // for promise-android-tools (native binaries)
     "node_modules/@babel/runtime/**/*" // for android-tools-bin
   ],
   extraMetadata: {

--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -243,7 +243,7 @@ class Reporter {
         let issueUrl =
           "https://github.com/ubports/ubports-installer/issues/new";
         if (data) {
-          issueUrl += `?title=${encodeURIComponent(data.title)}`;
+          issueUrl += `?title=${encodeURIComponent(data.title)}&body=${encodeURIComponent(body)}`;
         }
         shell.openExternal(issueUrl);
       })


### PR DESCRIPTION
## Problem

The macOS ARM64 build crashes on launch with `MODULE_NOT_FOUND` for `android-tools-bin`.

## Root Cause

The `promise-android-tools` package depends on `android-tools-bin` which contains native binaries (adb, fastboot, heimdall). The `android-tools-bin` package was not listed in `asarUnpack` in `build.js`, so it got packed into the asar archive. On macOS ARM64, when the app tries to require it from within the asar, it fails because the native binaries need to be unpacked.

This was masked on x64 by stale build artifacts but the arm64 build exposed the missing unpack entry.

## Fix

Added `node_modules/android-tools-bin/**/*` to the `asarUnpack` array in `build.js`, alongside the other packages that contain native binaries.