### PR TITLE
Fix arm64 packaging on windows and mac

### DIFF
--- a/afterPack.js
+++ b/afterPack.js
@@ -19,6 +19,28 @@
 
 const fs = require("fs-extra");
 const path = require("path");
+const { Arch } = require("electron-builder");
+
+/**
+ * Make the x86 android tools discoverable on arm. android-tools-bin resolves
+ * arm64 to its "arm" directory, but ships no native binaries there for windows
+ * or darwin, so alias it to the x86 tools, which run under emulation. Does
+ * nothing on platforms that do ship native arm binaries.
+ * @param {any} context - context
+ */
+function aliasArmTools(context) {
+  const os = context.electronPlatformName;
+  const toolsDir = path.join(
+    context.packager.getResourcesDir(context.appOutDir),
+    "app.asar.unpacked/node_modules/android-tools-bin/dist",
+    os
+  );
+
+  if (fs.existsSync(path.join(toolsDir, "arm"))) return;
+
+  fs.copySync(path.join(toolsDir, "x86"), path.join(toolsDir, "arm"));
+  console.log(`aliased android-tools-bin ${os}/x86 to ${os}/arm`);
+}
 
 /**
  * Wrap the packaged application to avoid having to use double dashes -- before passing command-line arguments
@@ -27,6 +49,10 @@ const path = require("path");
 module.exports = async function (context) {
   const distDir = context.appOutDir;
   var wrapperScript;
+
+  if (context.arch === Arch.arm64 || context.arch === Arch.armv7l) {
+    aliasArmTools(context);
+  }
 
   if (context.targets.find(target => target.name === "deb")) {
     wrapperScript = `#!/bin/bash

--- a/build.js
+++ b/build.js
@@ -61,6 +61,13 @@ cli
 
 const opts = cli.opts();
 
+if (!fs.existsSync(path.join(__dirname, "public/build/bundle.js"))) {
+  console.error(
+    "public/build/bundle.js is missing, run 'npm run build' before packaging"
+  );
+  process.exit(1);
+}
+
 const toolsArch = opts.arch.includes("arm") ? "arm" : "x86";
 const hasNativeTools = fs.existsSync(
   path.join(

--- a/build.js
+++ b/build.js
@@ -21,6 +21,8 @@
 
 const builder = require("electron-builder");
 const { Command } = require("commander");
+const fs = require("fs");
+const path = require("path");
 const cli = new Command();
 
 const PLATFORMS = ["darwin", "win32", "linux"];
@@ -59,6 +61,16 @@ cli
 
 const opts = cli.opts();
 
+const toolsArch = opts.arch.includes("arm") ? "arm" : "x86";
+const hasNativeTools = fs.existsSync(
+  path.join(
+    __dirname,
+    "node_modules/android-tools-bin/dist",
+    opts.os,
+    toolsArch
+  )
+);
+
 var targetOs;
 var buildConfig = {
   appId: "com.ubports.installer",
@@ -76,13 +88,18 @@ var buildConfig = {
       p => `!node_modules/android-tools-bin/dist/${p}`
     ),
     // exclude binaries for other architectures
-    `!node_modules/android-tools-bin/dist/**/${
-      opts.arch.includes("arm") ? "x86" : "arm"
-    }/**`
+    ...(hasNativeTools
+      ? [
+          `!node_modules/android-tools-bin/dist/**/${
+            toolsArch === "arm" ? "x86" : "arm"
+          }/**`
+        ]
+      : [])
   ],
   asarUnpack: [
     // Unpack dependencies of pakcages containing binaries
     "node_modules/7zip-min/*", // for 7zip-bin
+    "node_modules/android-tools-bin/**/*",
     "node_modules/jsonfile/**/*", // for fs-extra
     "node_modules/at-least-node/**/*", // for fs-extra
     "node_modules/graceful-fs/**/*", // for fs-extra

--- a/build.js
+++ b/build.js
@@ -112,7 +112,8 @@ var buildConfig = {
   extraMetadata: {
     package: opts.package === "portable" ? "exe" : opts.package,
     ...opts.extraMetadata
-  }
+  },
+  afterPack: "./afterPack.js"
 };
 
 const target = {
@@ -140,8 +141,7 @@ switch (opts.os) {
           "android-tools-fastboot",
           "heimdall-flash"
         ]
-      },
-      afterPack: "./afterPack.js"
+      }
     });
     break;
   case "win32":

--- a/build.js
+++ b/build.js
@@ -55,7 +55,7 @@ cli
     "-e, --extra-metadata [JSON]",
     "extra data for package.json",
     JSON.parse,
-    "{}"
+    {}
   )
   .parse(process.argv);
 

--- a/build.js
+++ b/build.js
@@ -170,7 +170,7 @@ switch (opts.os) {
 const build = () =>
   builder
     .build({
-      targets: builder.createTargets([targetOs]),
+      targets: builder.createTargets([targetOs], null, opts.arch),
       config: buildConfig
     })
     .then(() => console.log("build complete"))

--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/7zip-bin": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz",
-      "integrity": "sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
       "license": "MIT"
     },
     "node_modules/7zip-min": {
@@ -3286,13 +3286,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/builder-util/node_modules/7zip-bin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
-      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/builder-util/node_modules/fs-extra": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "winston": "^3.17.0",
     "yaml": "^2.8.0"
   },
+  "overrides": {
+    "7zip-bin": "^5.2.0"
+  },
   "engines": {
     "node": "^18"
   }


### PR DESCRIPTION
Fixes the arm64 installer dying on mac and windows.

`android-tools-bin` only ships native arm binaries for linux, so on windows and mac the arch filter dropped the only tools we have.

Two build.js bugs found on the way are fixed in their own commits: -a arm64 also built an x64 package, and the extra-metadata default was never run through `JSON.parse`.

Tested on windows arm64 (snapdragon X elite) and mac arm64 (m4 mini).